### PR TITLE
Membership timeout

### DIFF
--- a/lib/omscore/members/body_membership.ex
+++ b/lib/omscore/members/body_membership.ex
@@ -5,6 +5,10 @@ defmodule Omscore.Members.BodyMembership do
 
   schema "body_memberships" do
     field :comment, :string
+    field :fee, :decimal
+    field :fee_currency, :string
+    field :expiration, :naive_datetime
+    field :has_expired, :boolean
     belongs_to :body, Omscore.Core.Body
     belongs_to :member, Omscore.Members.Member
 
@@ -14,8 +18,18 @@ defmodule Omscore.Members.BodyMembership do
   @doc false
   def changeset(body_membership, attrs) do
     body_membership
-    |> cast(attrs, [:comment])
+    |> cast(attrs, [:comment, :fee, :fee_currency, :expiration])
     |> validate_required([])
+    |> validate_expiration
     |> unique_constraint(:body_membership_unique, name: :body_memberships_body_id_member_id_index)
   end
+
+  defp validate_expiration(%Ecto.Changeset{changes: %{expiration: expiration}} = changeset) when expiration != nil do
+    if NaiveDateTime.compare(expiration, NaiveDateTime.utc_now()) == :lt do
+      add_error(changeset, :expiration, "Memberships can not expire in the past")
+    else
+      change(changeset, has_expired: false)
+    end
+  end
+  defp validate_expiration(changeset), do: changeset
 end

--- a/lib/omscore_web/views/body_membership_view.ex
+++ b/lib/omscore_web/views/body_membership_view.ex
@@ -30,6 +30,7 @@ defmodule OmscoreWeb.BodyMembershipView do
       fee_currency: body_membership.fee_currency,
       expiration: body_membership.expiration,
       has_expired: body_membership.has_expired,
+      inserted_at: body_membership.inserted_at,
       member_id: body_membership.member_id,
       body_id: body_membership.body_id,
       member: Helper.render_assoc_one(body_membership.member, OmscoreWeb.MemberView, "member.json"),

--- a/lib/omscore_web/views/body_membership_view.ex
+++ b/lib/omscore_web/views/body_membership_view.ex
@@ -26,6 +26,10 @@ defmodule OmscoreWeb.BodyMembershipView do
   def render("body_membership.json", %{body_membership: body_membership}) do
     %{id: body_membership.id,
       comment: body_membership.comment,
+      fee: body_membership.fee,
+      fee_currency: body_membership.fee_currency,
+      expiration: body_membership.expiration,
+      has_expired: body_membership.has_expired,
       member_id: body_membership.member_id,
       body_id: body_membership.body_id,
       member: Helper.render_assoc_one(body_membership.member, OmscoreWeb.MemberView, "member.json"),

--- a/priv/repo/migrations/20180725100204_alter_body_membership_expiration.exs
+++ b/priv/repo/migrations/20180725100204_alter_body_membership_expiration.exs
@@ -1,0 +1,13 @@
+defmodule Omscore.Repo.Migrations.AlterBodyMembershipExpiration do
+  use Ecto.Migration
+
+  def change do
+    alter table(:body_memberships) do
+      add :fee, :decimal, default: nil
+      add :fee_currency, :string, default: "euro"
+      add :expiration, :naive_datetime, default: nil
+      add :has_expired, :boolean, default: false
+
+    end
+  end
+end

--- a/test/omscore/members/members_test.exs
+++ b/test/omscore/members/members_test.exs
@@ -366,7 +366,6 @@ defmodule Omscore.MembersTest do
       assert {:error, _bm} = Members.update_body_membership(bm, %{fee: 12.0, fee_currency: "euro", expiration: Omscore.ecto_date_in_past(10)})
     end
 
-    @tag only: 1
     test "automatically sets the has_expired flag to false when membership expired" do
       member = member_fixture()
       body = body_fixture()

--- a/test/omscore/members/members_test.exs
+++ b/test/omscore/members/members_test.exs
@@ -345,6 +345,26 @@ defmodule Omscore.MembersTest do
       assert {:ok, _} = Members.delete_body_membership(bm)
       assert nil == Members.get_body_membership(body, member)
     end
+
+    test "body membership has an expiration date and a fee" do
+      member = member_fixture()
+      body = body_fixture()
+      assert {:ok, bm} = Members.create_body_membership(body, member)
+
+      assert {:ok, bm} = Members.update_body_membership(bm, %{fee: 12.0, fee_currency: "euro", expiration: Omscore.ecto_date_in_past(-10)})
+      assert bm = Members.get_body_membership!(bm.id)
+      assert Decimal.equal?(bm.fee, 12)
+      assert bm.fee_currency == "euro"
+      assert bm.expiration
+      assert bm.has_expired == false
+    end
+
+    test "does not allow setting an expiration in the past" do
+      member = member_fixture()
+      body = body_fixture()
+      assert {:ok, bm} = Members.create_body_membership(body, member)
+      assert {:error, _bm} = Members.update_body_membership(bm, %{fee: 12.0, fee_currency: "euro", expiration: Omscore.ecto_date_in_past(10)})
+    end
   end
 
   describe "circle_memberships" do


### PR DESCRIPTION
I added the fields
fee (decimal)
fee_currency (string)
expiration (datetime)
has_expired (boolean)
inserted_at (datetime)
to the body_membership relationship. Datetimes are without timezone information. has_expired is a boolean that will be set to true as soon as the expiration mail has been sent. Inserted_at is the time the membership record was inserted into the database, which is the moment the member joined.
I will update apiary as soon as the PR is accepted.
