### PR TITLE
Body classifications

### DIFF
--- a/lib/omscore/core/body.ex
+++ b/lib/omscore/core/body.ex
@@ -10,6 +10,7 @@ defmodule Omscore.Core.Body do
     field :legacy_key, :string
     field :name, :string
     field :phone, :string
+    field :type, :string
 
     has_many :circles, Omscore.Core.Circle
     many_to_many :members, Omscore.Members.Member, join_through: Omscore.Members.BodyMembership
@@ -23,7 +24,7 @@ defmodule Omscore.Core.Body do
   @doc false
   def changeset(body, attrs) do
     body
-    |> cast(attrs, [:name, :email, :phone, :address, :description, :legacy_key, :shadow_circle_id])
+    |> cast(attrs, [:name, :email, :phone, :address, :description, :legacy_key, :shadow_circle_id, :type])
     |> validate_required([:name, :legacy_key, :address, :email])
     |> validate_shadow_circle()
   end

--- a/lib/omscore/core/core.ex
+++ b/lib/omscore/core/core.ex
@@ -33,6 +33,7 @@ defmodule Omscore.Core do
     from(u in Permission, order_by: [:object, :action, :scope])
     |> OmscoreWeb.Helper.paginate(params)
     |> OmscoreWeb.Helper.search(params, [:object, :action, :scope], ":")
+    |> OmscoreWeb.Helper.filter(params, Permission.__schema__(:fields))
     |> Repo.all()
   end
 
@@ -185,7 +186,8 @@ defmodule Omscore.Core do
   def list_bodies(params \\ %{}) do
     from(u in Body, order_by: [:name])
     |> OmscoreWeb.Helper.paginate(params)
-    |> OmscoreWeb.Helper.search(params, [:name, :legacy_key])
+    |> OmscoreWeb.Helper.search(params, [:name, :legacy_key], " ")
+    |> OmscoreWeb.Helper.filter(params, Body.__schema__(:fields))
     |> Repo.all
   end
 
@@ -232,7 +234,8 @@ defmodule Omscore.Core do
   def list_circles(params \\ %{}) do
     from(u in Circle, order_by: :name)
     |> OmscoreWeb.Helper.paginate(params)
-    |> OmscoreWeb.Helper.search(params, [:name])
+    |> OmscoreWeb.Helper.search(params, [:name], " ")
+    |> OmscoreWeb.Helper.filter(params, Circle.__schema__(:fields))
     |> Repo.all
   end
 
@@ -240,7 +243,8 @@ defmodule Omscore.Core do
   def list_free_circles(params \\ %{}) do
     from(u in Circle, where: is_nil(u.body_id), order_by: :name)
     |> OmscoreWeb.Helper.paginate(params)
-    |> OmscoreWeb.Helper.search(params, [:name])
+    |> OmscoreWeb.Helper.search(params, [:name], " ")
+    |> OmscoreWeb.Helper.filter(params, Circle.__schema__(:fields))
     |> Repo.all
   end
 
@@ -250,7 +254,8 @@ defmodule Omscore.Core do
   def list_bound_circles_(body_id, params) do
     from(u in Circle, where: u.body_id == ^body_id, order_by: :name)
     |> OmscoreWeb.Helper.paginate(params)
-    |> OmscoreWeb.Helper.search(params, [:name])
+    |> OmscoreWeb.Helper.search(params, [:name], " ")
+    |> OmscoreWeb.Helper.filter(params, Circle.__schema__(:fields))
     |> Repo.all
   end
 

--- a/lib/omscore/members/members.ex
+++ b/lib/omscore/members/members.ex
@@ -14,7 +14,8 @@ defmodule Omscore.Members do
   def list_members(params \\ %{}) do
     from(u in Member, order_by: [:last_name, :first_name])
     |> Helper.paginate(params)
-    |> Helper.search(params, [:first_name, :last_name])
+    |> Helper.search(params, [:first_name, :last_name], " ")
+    |> OmscoreWeb.Helper.filter(params, Member.__schema__(:fields))
     |> Repo.all
   end
 
@@ -105,7 +106,8 @@ defmodule Omscore.Members do
   # Get all join requests for a body
   def list_join_requests(%Omscore.Core.Body{} = body, params \\ %{}) do
     members_query = from(u in Member)
-    |> Helper.search(params, [:first_name, :last_name])
+    |> Helper.search(params, [:first_name, :last_name], " ")
+    |> OmscoreWeb.Helper.filter(params, Member.__schema__(:fields))
 
     jr_query = from(jr in JoinRequest, where: jr.body_id == ^body.id)
     |> Ecto.Query.join(:inner, [jr], u in subquery(members_query), jr.member_id == u.id)
@@ -174,7 +176,8 @@ defmodule Omscore.Members do
   def list_body_memberships(%Omscore.Core.Body{} = body, params), do: list_body_memberships(body.id, params)
   def list_body_memberships(body_id, params) do
     members_query = from(u in Member)
-    |> Helper.search(params, [:first_name, :last_name])
+    |> Helper.search(params, [:first_name, :last_name], " ")
+    |> OmscoreWeb.Helper.filter(params, Member.__schema__(:fields))
 
     bm_query = from(bm in BodyMembership, where: bm.body_id == ^body_id)
     |> Ecto.Query.join(:inner, [bm], u in subquery(members_query), bm.member_id == u.id)
@@ -233,7 +236,8 @@ defmodule Omscore.Members do
   # Searching is done in the fields of the member
   def list_circle_memberships(%Circle{} = circle, params) do
     members_query = from(u in Member)
-    |> Helper.search(params, [:first_name, :last_name])
+    |> Helper.search(params, [:first_name, :last_name], " ")
+    |> OmscoreWeb.Helper.filter(params, Member.__schema__(:fields))
 
     cm_query = from(cm in CircleMembership, where: cm.circle_id == ^circle.id)
     |> Ecto.Query.join(:inner, [cm], u in subquery(members_query), cm.member_id == u.id)
@@ -247,7 +251,8 @@ defmodule Omscore.Members do
   # Searches in the circle fields in case a search is passed
   def list_circle_memberships(%Member{} = member, params) do
     circle_query = from(u in Circle)
-    |> Helper.search(params, [:name, :description])
+    |> Helper.search(params, [:name, :description], " ")
+    |> OmscoreWeb.Helper.filter(params, Circle.__schema__(:fields))
 
     cm_query = from(cm in CircleMembership, where: cm.member_id == ^member.id)
     |> Ecto.Query.join(:inner, [cm], u in subquery(circle_query), cm.circle_id == u.id)

--- a/lib/omscore/registration/registration.ex
+++ b/lib/omscore/registration/registration.ex
@@ -23,14 +23,16 @@ defmodule Omscore.Registration do
   def list_campaigns(params \\ %{}) do
     from(u in Campaign, order_by: [:name])
     |> Helper.paginate(params)
-    |> Helper.search(params, [:name, :description_short, :url])
+    |> Helper.search(params, [:name, :description_short, :url], " ")
+    |> OmscoreWeb.Helper.filter(params, Campaign.__schema__(:fields))
     |> Repo.all
   end
 
   def list_active_campaigns(params \\ %{}) do
     from(u in Campaign, order_by: [:name], where: u.active == true)
     |> Helper.paginate(params)
-    |> Helper.search(params, [:name, :description_short, :url])
+    |> Helper.search(params, [:name, :description_short, :url], " ")
+    |> OmscoreWeb.Helper.filter(params, Campaign.__schema__(:fields))
     |> Repo.all
   end
 

--- a/lib/omscore_web/helper.ex
+++ b/lib/omscore_web/helper.ex
@@ -50,4 +50,18 @@ defmodule OmscoreWeb.Helper do
   end
   def search(query, _params, attrs) when length(attrs) != 0, do: query
 
+  # Filters the result based attribute-value filters and not a fuzzy search
+  # It checks for occurances like filter.attribute=value in params
+  def filter(query, params, [attribute | remaining_attributes]) do
+    key = "filter." <> Atom.to_string(attribute)
+    query = if Map.has_key?(params, key) do
+      querystring = params[key]
+      from q in query, where: ilike(field(q, ^attribute), ^"#{querystring}")
+    else
+      query
+    end
+    filter(query, params, remaining_attributes)
+  end
+  def filter(query, _params, []), do: query
+
 end

--- a/lib/omscore_web/views/body_view.ex
+++ b/lib/omscore_web/views/body_view.ex
@@ -30,6 +30,7 @@ defmodule OmscoreWeb.BodyView do
       address: body.address,
       description: body.description,
       legacy_key: body.legacy_key,
+      type: body.type,
       shadow_circle_id: body.shadow_circle_id,
       circles: Helper.render_assoc_many(body.circles, OmscoreWeb.CircleView, "circle.json"),
       shadow_circle: Helper.render_assoc_one(body.shadow_circle, OmscoreWeb.CircleView, "circle.json")

--- a/priv/repo/migrations/20180726144659_alter_body_type.exs
+++ b/priv/repo/migrations/20180726144659_alter_body_type.exs
@@ -1,0 +1,10 @@
+defmodule Omscore.Repo.Migrations.AlterBodyType do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bodies) do
+      add :type, :string, default: nil
+
+    end
+  end
+end

--- a/test/omscore/helpers_test.exs
+++ b/test/omscore/helpers_test.exs
@@ -138,4 +138,42 @@ defmodule Omscore.HelpersTest do
 
     end
   end
+
+  describe "filter" do
+    test "filters by a field" do
+      member1 = member_fixture(%{first_name: "hans"})
+      member2 = member_fixture(%{first_name: "hAnS"})
+      member3 = member_fixture(%{first_name: "Peter"})
+      member4 = member_fixture(%{first_name: "Hanseatic"})
+      member5 = member_fixture(%{first_name: "antihans"})
+
+      res = from(u in Members.Member)
+      |> Helper.filter(%{"filter.first_name" => "hans"}, Omscore.Members.Member.__schema__(:fields))
+      |> Repo.all
+
+      assert Enum.any?(res, fn(x) -> x.id == member1.id end)
+      assert Enum.any?(res, fn(x) -> x.id == member2.id end)
+      assert !Enum.any?(res, fn(x) -> x.id == member3.id end)
+      assert !Enum.any?(res, fn(x) -> x.id == member4.id end)
+      assert !Enum.any?(res, fn(x) -> x.id == member5.id end)
+    end
+
+    test "does no weird things if you pass a nonexisting filter field" do
+      member1 = member_fixture(%{first_name: "hans"})
+      member2 = member_fixture(%{first_name: "hAnS"})
+      member3 = member_fixture(%{first_name: "Peter"})
+      member4 = member_fixture(%{first_name: "Hanseatic"})
+      member5 = member_fixture(%{first_name: "antihans"})
+
+      res = from(u in Members.Member)
+      |> Helper.filter(%{"filter.first_name" => "hans", "filter.__meta__" => "'; OR TRUE"}, Omscore.Members.Member.__schema__(:fields))
+      |> Repo.all
+
+      assert Enum.any?(res, fn(x) -> x.id == member1.id end)
+      assert Enum.any?(res, fn(x) -> x.id == member2.id end)
+      assert !Enum.any?(res, fn(x) -> x.id == member3.id end)
+      assert !Enum.any?(res, fn(x) -> x.id == member4.id end)
+      assert !Enum.any?(res, fn(x) -> x.id == member5.id end)
+    end
+  end
 end

--- a/test/omscore_web/controllers/body_controller_test.exs
+++ b/test/omscore_web/controllers/body_controller_test.exs
@@ -82,6 +82,16 @@ defmodule OmscoreWeb.BodyControllerTest do
       assert res = json_response(conn, 200)["data"]
       assert !Enum.any?(res, fn(x) -> Map.has_key?(x, "name") end)
     end
+
+    test "filters the result if filters are passed", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "view", object: "body"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      create_many_bodies(0..100)
+
+      conn = get conn, body_path(conn, :index), [{"filter.name", "some really exotic query that definitely doesn't match any member at all"}]
+      assert json_response(conn, 200)["data"] == []
+    end
   end
 
   describe "show" do


### PR DESCRIPTION
I added a filter function on all GET listing requests where you can set a filter like ?filter.varname=value. Also I added a string field type to the body table
The combination of the two allows for easier searching within bodies and "classification" of bodies. Possible constraints on existing types can be made by the frontend.