### PR TITLE
Local permissions for bound campaigns

### DIFF
--- a/lib/omscore_web/controllers/campaign_controller.ex
+++ b/lib/omscore_web/controllers/campaign_controller.ex
@@ -54,7 +54,10 @@ defmodule OmscoreWeb.CampaignController do
   def show_full(conn, %{"campaign_id" => campaign_id}) do
     campaign = Registration.get_campaign!(campaign_id)
     |> Omscore.Repo.preload([submissions: [:user], autojoin_body: []])
-    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view", "campaign") do
+
+    permissions = update_local_permissions(conn.assigns.member, conn.assigns.permissions, campaign.autojoin_body_id)
+
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(permissions, "view", "campaign") do
       render(conn, "show.json", campaign: campaign, filters: filters)
     end
   end

--- a/lib/omscore_web/controllers/campaign_controller.ex
+++ b/lib/omscore_web/controllers/campaign_controller.ex
@@ -74,7 +74,10 @@ defmodule OmscoreWeb.CampaignController do
 
   def delete(conn, %{"id" => id}) do
     campaign = Registration.get_campaign!(id)
-    with {:ok, _} <- Core.search_permission_list(conn.assigns.permissions, "delete", "campaign"),
+
+    permissions = update_local_permissions(conn.assigns.member, conn.assigns.permissions, campaign.autojoin_body_id)
+
+    with {:ok, _} <- Core.search_permission_list(permissions, "delete", "campaign"),
          {:ok, %Campaign{}} <- Registration.delete_campaign(campaign) do
       send_resp(conn, :no_content, "")
     end


### PR DESCRIPTION
Recruitment campaign can now also be bound, which means that if they have a autojoin_body_id they are assigned local:blabla permissions for that body.