### PR TITLE
Fix password reset link

### DIFF
--- a/lib/omscore/auth/auth.ex
+++ b/lib/omscore/auth/auth.ex
@@ -207,7 +207,7 @@ defmodule Omscore.Auth do
   end
 
   defp send_password_reset_mail(user, token) do
-    url = Application.get_env(:omscore, :url_prefix) <> "/password_reset?token=" <> token
+    url = Application.get_env(:omscore, :url_prefix) <> "/password_confirm?token=" <> token
     Omscore.Interfaces.Mail.send_mail(user.email, "Reset your password", 
       "To reset your password, visit " <> url <> " or copy&paste this token into the input on the website: " <> token)
   end

--- a/test/omscore_web/controllers/login_controller_test.exs
+++ b/test/omscore_web/controllers/login_controller_test.exs
@@ -404,9 +404,9 @@ defmodule OmscoreWeb.LoginControllerTest do
 
   defp parse_url_from_mail({_, _, content, _}) do
     # Parse the url token from a content which looks like this:
-    # To reset your password, visit www.alastair.com/registration/password_reset?token=vXMkHWvQETck73sjQpccFDgQQuavIoDZ
+    # To reset your password, visit my.aegee.eu/registration/password_confirm?token=vXMkHWvQETck73sjQpccFDgQQuavIoDZ
 
-    Application.get_env(:omscore, :url_prefix) <> "/password_reset?token="
+    Application.get_env(:omscore, :url_prefix) <> "/password_confirm?token="
     |> Regex.escape
     |> Kernel.<>("([^\s]*)")
     |> Regex.compile!


### PR DESCRIPTION
There's a /password-reset (where you trigger the password reset) and /password_confirm, where you enter your token and new password. Currently oms-core-elixir sends the link with the 1st link, and when user goes to that link, the new password reset is triggered. I've fixed that.

Fixes https://oms-project.atlassian.net/projects/MEMB/issues/MEMB-272.