### PR TITLE
Fixes memb-286

### DIFF
--- a/lib/omscore/auth/auth.ex
+++ b/lib/omscore/auth/auth.ex
@@ -188,6 +188,9 @@ defmodule Omscore.Auth do
   def trigger_password_reset(email) do
     user = get_user_by_email!(email)
 
+    query = from u in PasswordReset, where: u.user_id == ^user.id
+    Repo.delete_all(query)
+
     with {:ok, password_reset, url} <- create_password_reset_object(user),
          {:ok} <- send_password_reset_mail(user, url),
     do: {:ok, password_reset}

--- a/test/omscore/auth/auth_test.exs
+++ b/test/omscore/auth/auth_test.exs
@@ -207,6 +207,18 @@ defmodule Omscore.AuthTest do
       assert Enum.any?(res, fn(x) -> x.user_id == user.id end)
     end
 
+    test "trigger_password_reset allows only one active password reset per user" do
+      user = user_fixture()
+      
+      assert {:ok, _} = Auth.trigger_password_reset(user.email)
+      res = Repo.all(Auth.PasswordReset)
+      assert Enum.count(res, fn(x) -> x.user_id == user.id end) == 1
+
+      assert {:ok, _} = Auth.trigger_password_reset(user.email)
+      res = Repo.all(Auth.PasswordReset)
+      assert Enum.count(res, fn(x) -> x.user_id == user.id end) == 1
+    end
+
     test "create_password_reset_object/1 returns a password_reset and a url which is not directly stored in db" do
       user = user_fixture()
       assert {:ok, _, url} = Auth.create_password_reset_object(user)

--- a/test/omscore/auth/auth_test.exs
+++ b/test/omscore/auth/auth_test.exs
@@ -209,7 +209,7 @@ defmodule Omscore.AuthTest do
 
     test "trigger_password_reset allows only one active password reset per user" do
       user = user_fixture()
-      
+
       assert {:ok, _} = Auth.trigger_password_reset(user.email)
       res = Repo.all(Auth.PasswordReset)
       assert Enum.count(res, fn(x) -> x.user_id == user.id end) == 1
@@ -217,6 +217,25 @@ defmodule Omscore.AuthTest do
       assert {:ok, _} = Auth.trigger_password_reset(user.email)
       res = Repo.all(Auth.PasswordReset)
       assert Enum.count(res, fn(x) -> x.user_id == user.id end) == 1
+    end
+
+    test "trigger_password_reset leaves other users password resets intact" do
+      user1 = user_fixture()
+      user2 = user_fixture(%{name: "some other name", email: "someother@email.com"})
+      
+      assert {:ok, _} = Auth.trigger_password_reset(user1.email)
+      res = Repo.all(Auth.PasswordReset)
+      assert Enum.count(res, fn(x) -> x.user_id == user1.id end) == 1
+
+      assert {:ok, _} = Auth.trigger_password_reset(user2.email)
+      res = Repo.all(Auth.PasswordReset)
+      assert Enum.count(res, fn(x) -> x.user_id == user2.id end) == 1
+
+      assert {:ok, _} = Auth.trigger_password_reset(user2.email)
+      res = Repo.all(Auth.PasswordReset)
+      assert Enum.count(res, fn(x) -> x.user_id == user2.id end) == 1
+      assert Enum.count(res, fn(x) -> x.user_id == user1.id end) == 1
+
     end
 
     test "create_password_reset_object/1 returns a password_reset and a url which is not directly stored in db" do


### PR DESCRIPTION
Old password reset tokens are invalidated for a user when he requests a new password reset token