### PR TITLE
Made type field in bodies mandatory and an enum-like thing 

### DIFF
--- a/lib/omscore/core/body.ex
+++ b/lib/omscore/core/body.ex
@@ -2,7 +2,7 @@ defmodule Omscore.Core.Body do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @body_types ["antenna", "contact antenna", "contact", "interest group", "working group", "commission", "committee", "other"]
+  @body_types ["antenna", "contact antenna", "contact", "interest group", "working group", "commission", "committee", "project", "partner", "other"]
 
 
   schema "bodies" do

--- a/lib/omscore/core/body.ex
+++ b/lib/omscore/core/body.ex
@@ -2,6 +2,8 @@ defmodule Omscore.Core.Body do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @body_types ["antenna", "contact antenna", "contact", "interest group", "working group", "commission", "committee", "other"]
+
 
   schema "bodies" do
     field :address, :string
@@ -25,7 +27,8 @@ defmodule Omscore.Core.Body do
   def changeset(body, attrs) do
     body
     |> cast(attrs, [:name, :email, :phone, :address, :description, :legacy_key, :shadow_circle_id, :type])
-    |> validate_required([:name, :legacy_key, :address, :email])
+    |> validate_required([:name, :legacy_key, :address, :email, :type])
+    |> validate_inclusion(:type, @body_types, message: "must be one of " <> Kernel.inspect(@body_types))
     |> validate_shadow_circle()
   end
 

--- a/priv/repo/migrations/20181119080858_make_body_type_required.exs
+++ b/priv/repo/migrations/20181119080858_make_body_type_required.exs
@@ -2,6 +2,8 @@ defmodule Omscore.Repo.Migrations.MakeBodyTypeRequired do
   use Ecto.Migration
 
   def change do
+    execute "UPDATE bodies SET type=`antenna` WHERE type IS NULL;"
+
     alter table(:bodies) do
       modify :type, :string, default: "antenna", null: false
 

--- a/priv/repo/migrations/20181119080858_make_body_type_required.exs
+++ b/priv/repo/migrations/20181119080858_make_body_type_required.exs
@@ -2,7 +2,7 @@ defmodule Omscore.Repo.Migrations.MakeBodyTypeRequired do
   use Ecto.Migration
 
   def change do
-    execute "UPDATE bodies SET type=`antenna` WHERE type IS NULL;"
+    execute "UPDATE bodies SET type='antenna' WHERE type IS NULL;"
 
     alter table(:bodies) do
       modify :type, :string, default: "antenna", null: false

--- a/priv/repo/migrations/20181119080858_make_body_type_required.exs
+++ b/priv/repo/migrations/20181119080858_make_body_type_required.exs
@@ -1,0 +1,10 @@
+defmodule Omscore.Repo.Migrations.MakeBodyTypeRequired do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bodies) do
+      modify :type, :string, default: "antenna", null: false
+
+    end
+  end
+end

--- a/test/omscore/core/core_test.exs
+++ b/test/omscore/core/core_test.exs
@@ -204,7 +204,7 @@ defmodule Omscore.CoreTest do
   describe "bodies" do
     alias Omscore.Core.Body
 
-    @valid_attrs %{address: "some address", description: "some description", email: "some email", legacy_key: "some legacy_key", name: "some name", phone: "some phone"}
+    @valid_attrs %{address: "some address", description: "some description", email: "some email", legacy_key: "some legacy_key", name: "some name", phone: "some phone", type: "other"}
     @update_attrs %{address: "some updated address", description: "some updated description", email: "some updated email", legacy_key: "some updated legacy_key", name: "some updated name", phone: "some updated phone"}
     @invalid_attrs %{address: nil, description: nil, email: nil, legacy_key: nil, name: nil, phone: nil}
 
@@ -231,6 +231,11 @@ defmodule Omscore.CoreTest do
       assert body.legacy_key == "some legacy_key"
       assert body.name == "some name"
       assert body.phone == "some phone"
+      assert body.type == "other"
+    end
+
+    test "create_body/1 validates body_types" do
+      assert {:error, _} = Core.create_body(@valid_attrs |> Map.put(:type, "some_very weird type which doesn't exist"))    
     end
 
     test "create_body/1 ignores shadow_circle_id" do

--- a/test/omscore_web/controllers/body_controller_test.exs
+++ b/test/omscore_web/controllers/body_controller_test.exs
@@ -4,7 +4,7 @@ defmodule OmscoreWeb.BodyControllerTest do
   alias Omscore.Core
   alias Omscore.Core.Body
 
-  @create_attrs %{address: "some address", description: "some description", email: "some email", legacy_key: "some legacy_key", name: "some name", phone: "some phone"}
+  @create_attrs %{address: "some address", description: "some description", email: "some email", legacy_key: "some legacy_key", name: "some name", phone: "some phone", type: "other"}
   @update_attrs %{address: "some updated address", description: "some updated description", email: "some updated email", legacy_key: "some updated legacy_key", name: "some updated name", phone: "some updated phone"}
   @invalid_attrs %{address: nil, description: nil, email: nil, legacy_key: nil, name: nil, phone: nil}
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -103,7 +103,7 @@ defmodule OmscoreWeb.Fixtures do
     circle
   end
 
-  @body_attrs %{address: "some address", description: "some description", email: "some email", legacy_key: "some legacy_key", name: "some name", phone: "some phone"}
+  @body_attrs %{address: "some address", description: "some description", email: "some email", legacy_key: "some legacy_key", name: "some name", phone: "some phone", type: "antenna"}
   def body_fixture(attrs \\ %{}) do
     {:ok, body} =
       attrs


### PR DESCRIPTION
the type field is now mandatory and can only be one of some predefined values. Instead of creating a database default I figured it would be easier doing a manual SQL query which changes all unset body types to antenna in the production system. That way we are in control if something goes wrong