### PR TITLE
Added campain preloading per body

### DIFF
--- a/lib/omscore/core/body.ex
+++ b/lib/omscore/core/body.ex
@@ -17,6 +17,7 @@ defmodule Omscore.Core.Body do
     has_many :join_requests, Omscore.Members.JoinRequest
     has_many :body_memberships, Omscore.Members.BodyMembership
     belongs_to :shadow_circle, Omscore.Core.Circle
+    has_many :campaigns, Omscore.Registration.Campaign, foreign_key: :autojoin_body_id
 
     timestamps()
   end

--- a/lib/omscore/core/core.ex
+++ b/lib/omscore/core/core.ex
@@ -192,7 +192,7 @@ defmodule Omscore.Core do
   end
 
   # Gets a single body, circles preloaded
-  def get_body!(id), do: Repo.get!(Body, id) |> Repo.preload([:circles])
+  def get_body!(id), do: Repo.get!(Body, id) |> Repo.preload([:circles, :campaigns])
 
   def get_body_members(body) do
     body 

--- a/lib/omscore_web/views/body_view.ex
+++ b/lib/omscore_web/views/body_view.ex
@@ -33,7 +33,8 @@ defmodule OmscoreWeb.BodyView do
       type: body.type,
       shadow_circle_id: body.shadow_circle_id,
       circles: Helper.render_assoc_many(body.circles, OmscoreWeb.CircleView, "circle.json"),
-      shadow_circle: Helper.render_assoc_one(body.shadow_circle, OmscoreWeb.CircleView, "circle.json")
+      shadow_circle: Helper.render_assoc_one(body.shadow_circle, OmscoreWeb.CircleView, "circle.json"),
+      campaigns: Helper.render_assoc_many(body.campaigns, OmscoreWeb.CampaignView, "campaign.json")
     }
   end
 end

--- a/test/omscore_web/controllers/body_controller_test.exs
+++ b/test/omscore_web/controllers/body_controller_test.exs
@@ -122,6 +122,17 @@ defmodule OmscoreWeb.BodyControllerTest do
       assert res = json_response(conn, 200)["data"]
       assert !Map.has_key?(res, "name")
     end
+
+    test "shows campaigns of a body", %{conn: conn, body: body} do
+      %{token: token} = create_member_with_permissions([%{action: "view", object: "body"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      campaign = campaign_fixture(%{autojoin_body_id: body.id})
+
+      conn = get conn, body_body_path(conn, :show, body.id)
+      assert res = json_response(conn, 200)["data"]
+      assert Enum.any?(res["campaigns"], fn(x) -> x["id"] == campaign.id end)
+    end
   end
 
   describe "create body" do


### PR DESCRIPTION
This doesn't close memb-140 as there are some things to be done still:

- Create a filtered view permission in case normal users shouldn't be able to see the campaigns of a body
- Take the global campaign permissions away from boardies and use it only for CD/etc.
- Implement a frontend view of campaigns per body