### PR TITLE
Resend mail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ sudo: required
 services:
   - docker
 
+notifications:
+  slack: myaegee:jhn0jBOynuYf93wsSfJI1XQk
+
 before_script:
     - cd docker
     - sudo docker-compose -f docker-compose-secrets.yml -f docker-compose.yml build

--- a/config/config.exs
+++ b/config/config.exs
@@ -24,7 +24,8 @@ config :omscore,
   ttl_access: 60 * 60,                # 1 hour
   ttl_password_reset: 60 * 15,        # 15 Minutes
   ttl_mail_confirmation: 60 * 60 * 2, # 2 hours
-  expiry_worker_freq: 5 * 60 * 1000   # 5 Minutes
+  expiry_worker_freq: 5 * 60 * 1000,  # 5 Minutes
+  mail_confirmation_resends: 50       # How often a user can request resend of his confirmation mail within the expiration interval
 
 # Configures the endpoint
 config :omscore, OmscoreWeb.Endpoint,

--- a/lib/omscore/registration/registration.ex
+++ b/lib/omscore/registration/registration.ex
@@ -129,6 +129,7 @@ defmodule Omscore.Registration do
   end
 
   def get_submission!(submission_id), do: Repo.get!(Submission, submission_id)
+  def get_submission_by_token!(token), do: Repo.get_by!(Submission, token: token)
 
   def create_submission(campaign, user, submission_attrs) do
     %Submission{

--- a/lib/omscore/registration/submission.ex
+++ b/lib/omscore/registration/submission.ex
@@ -9,6 +9,7 @@ defmodule Omscore.Registration.Submission do
     field :last_name, :string
     field :motivation, :string
     field :mail_confirmed, :boolean
+    field :token, :string
 
     belongs_to :user, Omscore.Auth.User
     belongs_to :campaign, Omscore.Registration.Campaign
@@ -25,6 +26,14 @@ defmodule Omscore.Registration.Submission do
     |> validate_required([:first_name, :last_name, :motivation, :user_id, :campaign_id])
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:campaign_id)
+    |> put_token
   end
 
+  defp put_token(changeset) do
+    if get_field(changeset, :token) == nil || get_field(changeset, :token) == "" do
+      change(changeset, token: Omscore.random_url())
+    else
+      changeset
+    end
+  end
 end

--- a/lib/omscore_web/controllers/campaign_controller.ex
+++ b/lib/omscore_web/controllers/campaign_controller.ex
@@ -116,7 +116,7 @@ defmodule OmscoreWeb.CampaignController do
          {:ok, _data} <- Registration.send_confirmation_mail(user, submission) do
       conn
       |> put_status(:created)
-      |> render("success.json", msg: "Submission recorded successfully")
+      |> render("submit.json", campaign: submission)
     else
       {:error, {:unprocessable_entity, %{"errors" => errors}}} -> {:unprocessable_entity, %{errors: errors}}
       {:error, {status, errors}} -> {status, errors}

--- a/lib/omscore_web/controllers/fallback_controller.ex
+++ b/lib/omscore_web/controllers/fallback_controller.ex
@@ -18,7 +18,7 @@ defmodule OmscoreWeb.FallbackController do
     |> render(OmscoreWeb.ErrorView, "error.json", msg: "Not Found")
   end
 
-  def call(conn, {:error, status, message}) when status in [:forbidden, :not_found, :unprocessable_entity, :bad_request] do
+  def call(conn, {:error, status, message}) when status in [:forbidden, :not_found, :unprocessable_entity, :bad_request, :too_many_requests] do
     conn
     |> put_status(status)
     |> render(OmscoreWeb.ErrorView, "error.json", msg: message)

--- a/lib/omscore_web/router.ex
+++ b/lib/omscore_web/router.ex
@@ -40,7 +40,7 @@ defmodule OmscoreWeb.Router do
     get "/campaigns", CampaignController, :index
     get "/campaigns/:campaign_url", CampaignController, :show
     post "/campaigns/:campaign_url", CampaignController, :submit
-    post "/campaigns/:campaign_url/resend_mail/:submission_id", CampaignController, :resend_mail
+    post "/campaigns/:campaign_url/resend_mail/:submission_token", CampaignController, :resend_confirmation_mail
     post "/confirm_mail/:confirmation_url", CampaignController, :confirm_mail
   end
 

--- a/lib/omscore_web/router.ex
+++ b/lib/omscore_web/router.ex
@@ -40,6 +40,7 @@ defmodule OmscoreWeb.Router do
     get "/campaigns", CampaignController, :index
     get "/campaigns/:campaign_url", CampaignController, :show
     post "/campaigns/:campaign_url", CampaignController, :submit
+    post "/campaigns/:campaign_url/resend_mail/:submission_id", CampaignController, :resend_mail
     post "/confirm_mail/:confirmation_url", CampaignController, :confirm_mail
   end
 

--- a/lib/omscore_web/views/campaign_view.ex
+++ b/lib/omscore_web/views/campaign_view.ex
@@ -13,7 +13,7 @@ defmodule OmscoreWeb.CampaignView do
   end
 
   def render("submit.json", %{campaign: submission}) do
-    %{success: true, data: %{id: submission.id}}
+    %{success: true, data: %{token: submission.token}}
   end
 
   def render("campaign_public.json", %{campaign: campaign}) do

--- a/lib/omscore_web/views/campaign_view.ex
+++ b/lib/omscore_web/views/campaign_view.ex
@@ -12,6 +12,10 @@ defmodule OmscoreWeb.CampaignView do
     %{success: true, data: render_one(campaign, CampaignView, "campaign_public.json")}
   end
 
+  def render("submit.json", %{campaign: submission}) do
+    %{success: true, data: %{id: submission.id}}
+  end
+
   def render("campaign_public.json", %{campaign: campaign}) do
     %{name: campaign.name,
       url: campaign.url,

--- a/priv/repo/migrations/20181118163548_add_submission_token.exs
+++ b/priv/repo/migrations/20181118163548_add_submission_token.exs
@@ -1,0 +1,9 @@
+defmodule Omscore.Repo.Migrations.AddSubmissionToken do
+  use Ecto.Migration
+
+  def change do
+    alter table(:submissions) do
+      add :token, :string
+    end
+  end
+end

--- a/test/omscore/expire_tokens_test.exs
+++ b/test/omscore/expire_tokens_test.exs
@@ -63,4 +63,18 @@ defmodule Omscore.ExpireTokensTest do
 
     assert Repo.get!(Omscore.Registration.Submission, submission.id)
   end
+
+  test "leaves a submission intact in case the users mail was confirmed manually" do
+    %{submission: submission} = Omscore.ecto_date_in_past(Application.get_env(:omscore, :ttl_refresh) * 2)
+    |> token_fixture()
+
+    submission
+    |> Omscore.Registration.Submission.changeset(%{mail_confirmed: true})
+    |> Omscore.Repo.update!()
+
+    Omscore.ExpireTokens.handle_info(:work, {})
+
+    assert Repo.get!(Omscore.Registration.Submission, submission.id)
+
+  end
 end

--- a/test/omscore/registration/registration_test.exs
+++ b/test/omscore/registration/registration_test.exs
@@ -95,6 +95,16 @@ defmodule Omscore.RegistrationTest do
       assert submission |> map_inclusion(@valid_attrs)
     end
 
+    test "create automatically assigns a token" do
+      campaign = campaign_fixture()
+      user = user_fixture()
+
+      assert {:ok, submission} = Registration.create_submission(campaign, user, @valid_attrs)
+      assert submission = Registration.get_submission!(submission.id)
+      assert submission.token != nil
+      assert submission.token != ""
+    end
+
     test "create with invalid attrs throws an error" do
       campaign = campaign_fixture()
       user = user_fixture()

--- a/test/omscore_web/controllers/campaign_controller_test.exs
+++ b/test/omscore_web/controllers/campaign_controller_test.exs
@@ -450,6 +450,15 @@ defmodule OmscoreWeb.CampaignControllerTest do
       assert Enum.any?(campaign.submissions, fn(x) -> x.user_id == user.id end)
     end
 
+    test "a valid submission returns the id of the submission so the user can refer to it later", %{conn: conn, campaign: campaign} do
+      conn = post conn, campaign_path(conn, :submit, campaign.url), submission: @valid_submission
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      campaign = campaign |> Omscore.Repo.preload([:submissions])
+      assert campaign.submissions != []
+      assert Enum.any?(campaign.submissions, fn(x) -> x.id == id end)
+    end
+
     test "a invalid submission returns an error", %{conn: conn, campaign: campaign} do
       conn = post conn, campaign_path(conn, :submit, campaign.url), submission: @invalid_submission
       assert json_response(conn, 422)["errors"] != %{}


### PR DESCRIPTION
Adds a functionality to resend mails, requires a token the user gets upon submission of the registration. The request itself is this one: https://omscoreelixir.docs.apiary.io/#reference/recruitment-campaigns/resend-confirmation-mail/resend-confirmation-mail