### PR TITLE
Added request to view local campaigns

### DIFF
--- a/lib/omscore/registration/registration.ex
+++ b/lib/omscore/registration/registration.ex
@@ -36,6 +36,14 @@ defmodule Omscore.Registration do
     |> Repo.all
   end
 
+  def list_bound_campaigns(body_id, params \\ %{}) do
+    from(u in Campaign, order_by: [:name], where: u.autojoin_body_id == ^body_id)
+    |> Helper.paginate(params)
+    |> Helper.search(params, [:name, :description_short, :url], " ")
+    |> OmscoreWeb.Helper.filter(params, Campaign.__schema__(:fields))
+    |> Repo.all
+  end
+
   @doc """
   Gets a single campaign.
 

--- a/lib/omscore_web/controllers/body_controller.ex
+++ b/lib/omscore_web/controllers/body_controller.ex
@@ -14,6 +14,13 @@ defmodule OmscoreWeb.BodyController do
     end
   end
 
+  def index_campaigns(conn, params) do
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view", "campaign") do
+      campaigns = Omscore.Registration.list_bound_campaigns(conn.assigns.body.id, params)
+      render(conn, "index_campaigns.json", campaigns: campaigns, filters: filters)
+    end
+  end
+
   def create(conn, %{"body" => body_params}) do
     with {:ok, _} <- Core.search_permission_list(conn.assigns.permissions, "create", "body"),
          {:ok, %Body{} = body} <- Core.create_body(body_params) do

--- a/lib/omscore_web/router.ex
+++ b/lib/omscore_web/router.ex
@@ -128,6 +128,7 @@ defmodule OmscoreWeb.Router do
     delete "/members", BodyController, :delete_myself
     post "/members", JoinRequestController, :create
     get "/my_permissions", BodyController, :my_permissions
+    get "/campaigns", BodyController, :index_campaigns
 
     get "/join_requests", JoinRequestController, :index
     get "/join_requests/:id", JoinRequestController, :show

--- a/lib/omscore_web/views/body_view.ex
+++ b/lib/omscore_web/views/body_view.ex
@@ -12,6 +12,14 @@ defmodule OmscoreWeb.BodyView do
   end
   #def render("index.json", %{bodies: bodies}), do: render("index.json", %{bodies: bodies, filters: []})
 
+  def render("index_campaigns.json", %{campaigns: campaigns, filters: filters}) do
+    data = campaigns
+    |> render_many(OmscoreWeb.CampaignView, "campaign.json")
+    |> Omscore.Core.apply_attribute_filters(filters)
+
+    %{success: true, data: data}
+  end
+
   def render("show.json", %{body: body, filters: filters}) do
     data = body
     |> render_one(BodyView, "body.json")
@@ -33,8 +41,7 @@ defmodule OmscoreWeb.BodyView do
       type: body.type,
       shadow_circle_id: body.shadow_circle_id,
       circles: Helper.render_assoc_many(body.circles, OmscoreWeb.CircleView, "circle.json"),
-      shadow_circle: Helper.render_assoc_one(body.shadow_circle, OmscoreWeb.CircleView, "circle.json"),
-      campaigns: Helper.render_assoc_many(body.campaigns, OmscoreWeb.CampaignView, "campaign.json")
+      shadow_circle: Helper.render_assoc_one(body.shadow_circle, OmscoreWeb.CircleView, "circle.json")
     }
   end
 end

--- a/test/omscore/registration/registration_test.exs
+++ b/test/omscore/registration/registration_test.exs
@@ -15,6 +15,16 @@ defmodule Omscore.RegistrationTest do
       assert Registration.list_campaigns() |> Enum.any?(fn(x) -> x == campaign end)
     end
 
+    test "list_bound_campaigns returns all bound campaigns" do
+      campaign1 = campaign_fixture()
+      body = body_fixture()
+      campaign2 = campaign_fixture(%{autojoin_body_id: body.id, url: "some_other_url"})
+
+      res = Registration.list_bound_campaigns(body.id)
+      assert Enum.any?(res, fn(x) -> x == campaign2 end)
+      assert !Enum.any?(res, fn(x) -> x == campaign1 end)
+    end
+
     test "get_campaign!/1 returns the campaign with given id" do
       campaign = campaign_fixture()
       assert Registration.get_campaign!(campaign.id) == campaign


### PR DESCRIPTION
This should finally close off the memb-140 thing. The new request is bodies/id/campaigns, documented here: https://omscoreelixir.docs.apiary.io/#reference/body-related-requests/bound-recruitment-campaigns