### PR TITLE
Email case-insensitivity

### DIFF
--- a/lib/omscore/auth/auth.ex
+++ b/lib/omscore/auth/auth.ex
@@ -16,7 +16,7 @@ defmodule Omscore.Auth do
 
   def get_user!(id), do: Repo.get!(User, id)
 
-  def get_user_by_email!(email), do: Repo.get_by!(User, email: email)
+  def get_user_by_email!(email), do: Repo.get_by!(User, email: String.downcase(email))
   def get_user_by_member_id!(member_id) when is_binary(member_id) do
     {member_id, ""} = Integer.parse(member_id)
     get_user_by_member_id!(member_id)
@@ -156,7 +156,8 @@ defmodule Omscore.Auth do
 
   # Fetch a user from DB
   def authenticate_user(username, plain_text_password) do
-    query = from u in User, where: u.name == ^username or u.email == ^username
+    username_lowercase = String.downcase(username)
+    query = from u in User, where: u.name == ^username or u.email == ^username_lowercase
 
     with user <- Repo.one(query),
       {:ok, _user} <- check_password(user, plain_text_password),

--- a/lib/omscore/auth/user.ex
+++ b/lib/omscore/auth/user.ex
@@ -19,6 +19,7 @@ defmodule Omscore.Auth.User do
     user
     |> cast(attrs, [:name, :email, :password, :active])
     |> validate_required([:name, :email, :password])
+    |> downcase_email()
     |> validate_format(:email, ~r/^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/) # copy&pasted without understanding it, thanks stackoverflow
     |> validate_length(:password, min: 8)
     |> unique_constraint(:name)
@@ -30,4 +31,7 @@ defmodule Omscore.Auth.User do
     change(changeset, password: Comeonin.Bcrypt.hashpwsalt(password))
   end
   defp put_pass_hash(changeset), do: changeset
+
+  defp downcase_email(%Ecto.Changeset{changes: %{email: email} = changes} = changeset), do: Map.put(changeset, :changes, Map.put(changes, :email, String.downcase(email)))
+  defp downcase_email(changeset), do: changeset
 end

--- a/test/omscore/auth/auth_test.exs
+++ b/test/omscore/auth/auth_test.exs
@@ -62,6 +62,11 @@ defmodule Omscore.AuthTest do
       assert {:error, %Ecto.Changeset{}} = Auth.create_user(@update_attrs |> Map.put(:email, @valid_attrs.email))
     end
 
+    test "create_user/1 with duplicate email in different cases returns error" do
+      assert {:ok, %User{}} = Auth.create_user(@valid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Auth.create_user(@update_attrs |> Map.put(:email, String.upcase(@valid_attrs.email)))
+    end
+
     test "create_user/1 with duplicate username returns error" do
       assert {:ok, %User{}} = Auth.create_user(@valid_attrs)
       assert {:error, %Ecto.Changeset{}} = Auth.create_user(@update_attrs |> Map.put(:name, @valid_attrs.name))

--- a/test/omscore/auth/auth_test.exs
+++ b/test/omscore/auth/auth_test.exs
@@ -26,11 +26,23 @@ defmodule Omscore.AuthTest do
       assert Auth.get_user_by_member_id!("123")
     end
 
+    test "get_user_by_email!/1 returns the user with a given email" do
+      user_fixture(%{email: "some_weird@email.com"})
+      assert Auth.get_user_by_email!("some_weird@email.com")
+      assert Auth.get_user_by_email!("SOME_WEIRD@email.com")
+    end
+
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Auth.create_user(@valid_attrs)
       assert user.email == "some@email.com"
       assert user.name == "some name"
       assert Omscore.Auth.authenticate_user(user.name, "some password")
+    end
+
+    test "create_user/1 stores mails lowercase" do
+      assert {:ok, %User{} = user} = Auth.create_user(@valid_attrs |> Map.put(:email, "SOME@EmAiL.com"))
+      assert user = Auth.get_user!(user.id)
+      assert user.email == "some@email.com"
     end
 
     test "create_user/1 with invalid data returns error changeset" do
@@ -132,6 +144,11 @@ defmodule Omscore.AuthTest do
       user_fixture()
       assert {:ok, _user, _access, _refresh} = Omscore.Auth.login_user("some name", "some password")
       assert {:ok, _user, _access, _refresh} = Omscore.Auth.login_user("some@email.com", "some password")
+    end
+
+    test "login also works with case-mismatch on email" do
+      user_fixture()
+      assert {:ok, _user, _access, _refresh} = Omscore.Auth.login_user("SOME@EMAIL.com", "some password")
     end
 
     test "refute bad credentials" do


### PR DESCRIPTION
We should not merge this before we haven't manually deleted all duplicate mails, however this stores mails in lowercase and compares case insensitively