### PR TITLE
Separate fee payments

### DIFF
--- a/lib/omscore/core/body.ex
+++ b/lib/omscore/core/body.ex
@@ -20,6 +20,7 @@ defmodule Omscore.Core.Body do
     has_many :body_memberships, Omscore.Members.BodyMembership
     belongs_to :shadow_circle, Omscore.Core.Circle
     has_many :campaigns, Omscore.Registration.Campaign, foreign_key: :autojoin_body_id
+    has_many :payments, Omscore.Finances.Payment
 
     timestamps()
   end

--- a/lib/omscore/core/body.ex
+++ b/lib/omscore/core/body.ex
@@ -13,6 +13,7 @@ defmodule Omscore.Core.Body do
     field :name, :string
     field :phone, :string
     field :type, :string
+    field :pays_fees, :boolean
 
     has_many :circles, Omscore.Core.Circle
     many_to_many :members, Omscore.Members.Member, join_through: Omscore.Members.BodyMembership
@@ -28,7 +29,7 @@ defmodule Omscore.Core.Body do
   @doc false
   def changeset(body, attrs) do
     body
-    |> cast(attrs, [:name, :email, :phone, :address, :description, :legacy_key, :shadow_circle_id, :type])
+    |> cast(attrs, [:name, :email, :phone, :address, :description, :legacy_key, :shadow_circle_id, :type, :pays_fees])
     |> validate_required([:name, :legacy_key, :address, :email, :type])
     |> validate_inclusion(:type, @body_types, message: "must be one of " <> Kernel.inspect(@body_types))
     |> validate_shadow_circle()

--- a/lib/omscore/expire_tokens.ex
+++ b/lib/omscore/expire_tokens.ex
@@ -45,6 +45,7 @@ defmodule Omscore.ExpireTokens do
       # We need to first query them because we can't feed this complex query into an update statement
       items = Omscore.Repo.all(expire_query)
       |> Enum.filter(fn(x) -> x.body.pays_fees end)
+      #|> Enum.filter(fn(x) -> x.body.type in ["antenna", "contact antenna", "contact"] end)
 
       ids = Enum.map(items, fn(x) -> x.id end)
 

--- a/lib/omscore/expire_tokens.ex
+++ b/lib/omscore/expire_tokens.ex
@@ -44,6 +44,7 @@ defmodule Omscore.ExpireTokens do
 
       # We need to first query them because we can't feed this complex query into an update statement
       items = Omscore.Repo.all(expire_query)
+      |> Enum.filter(fn(x) -> x.body.pays_fees end)
 
       ids = Enum.map(items, fn(x) -> x.id end)
 

--- a/lib/omscore/finances/finances.ex
+++ b/lib/omscore/finances/finances.ex
@@ -62,12 +62,16 @@ defmodule Omscore.Finances do
 
   """
   def create_payment(%Omscore.Core.Body{} = body, %Omscore.Members.Member{} = member, attrs \\ %{}) do
-    %Payment{
+    changeset = %Payment{
       body_id: body.id,
       member_id: member.id
     }
     |> Payment.changeset(attrs)
-    |> Repo.insert()
+
+    with {:ok, payment} <- Repo.insert(changeset) do
+      Omscore.ExpireTokens.expire_memberships()
+      {:ok, payment}
+    end
   end
 
   @doc """

--- a/lib/omscore/finances/finances.ex
+++ b/lib/omscore/finances/finances.ex
@@ -1,0 +1,119 @@
+defmodule Omscore.Finances do
+  @moduledoc """
+  The Finances context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Omscore.Repo
+
+  alias Omscore.Finances.Payment
+
+  @doc """
+  Returns the list of payments.
+
+  ## Examples
+
+      iex> list_payments()
+      [%Payment{}, ...]
+
+  """
+  def list_payments(params \\ %{}) do
+    from(u in Payment, order_by: [:inserted_at])
+    |> OmscoreWeb.Helper.paginate(params)
+    |> OmscoreWeb.Helper.search(params, [:comment, :invoice_name, :invoice_address], " ")
+    |> OmscoreWeb.Helper.filter(params, Payment.__schema__(:fields))
+    |> Repo.all()
+  end
+
+  def list_bound_payments(body_id, params \\ %{}) do
+    from(u in Payment, order_by: [:inserted_at], where: u.body_id == ^body_id)
+    |> OmscoreWeb.Helper.paginate(params)
+    |> OmscoreWeb.Helper.search(params, [:comment, :invoice_name, :invoice_address], " ")
+    |> OmscoreWeb.Helper.filter(params, Payment.__schema__(:fields))
+    |> Repo.all()
+  end
+
+  @doc """
+  Gets a single payment.
+
+  Raises `Ecto.NoResultsError` if the Payment does not exist.
+
+  ## Examples
+
+      iex> get_payment!(123)
+      %Payment{}
+
+      iex> get_payment!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_payment!(id), do: Repo.get!(Payment, id)
+
+  @doc """
+  Creates a payment.
+
+  ## Examples
+
+      iex> create_payment(%{field: value})
+      {:ok, %Payment{}}
+
+      iex> create_payment(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_payment(%Omscore.Core.Body{} = body, %Omscore.Members.Member{} = member, attrs \\ %{}) do
+    %Payment{
+      body_id: body.id,
+      member_id: member.id
+    }
+    |> Payment.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a payment.
+
+  ## Examples
+
+      iex> update_payment(payment, %{field: new_value})
+      {:ok, %Payment{}}
+
+      iex> update_payment(payment, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_payment(%Payment{} = payment, attrs) do
+    payment
+    |> Payment.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Payment.
+
+  ## Examples
+
+      iex> delete_payment(payment)
+      {:ok, %Payment{}}
+
+      iex> delete_payment(payment)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_payment(%Payment{} = payment) do
+    Repo.delete(payment)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking payment changes.
+
+  ## Examples
+
+      iex> change_payment(payment)
+      %Ecto.Changeset{source: %Payment{}}
+
+  """
+  def change_payment(%Payment{} = payment) do
+    Payment.changeset(payment, %{})
+  end
+end

--- a/lib/omscore/finances/payment.ex
+++ b/lib/omscore/finances/payment.ex
@@ -1,0 +1,38 @@
+defmodule Omscore.Finances.Payment do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+
+  schema "payments" do
+    field :amount, :decimal
+    field :comment, :string
+    field :currency, :string
+    field :expires, :naive_datetime
+    field :invoice_address, :string
+    field :invoice_name, :string
+    field :member_id, :id
+    field :body_id, :id
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(payment, attrs) do
+    payment
+    |> cast(attrs, [:amount, :currency, :expires, :invoice_name, :invoice_address, :comment])
+    |> validate_required([:amount, :currency, :expires, :body_id])
+    |> validate_body_membership()
+  end
+
+  defp validate_body_membership(%Ecto.Changeset{valid?: true} = changeset) do
+    member_id = get_field(changeset, :member_id)
+    body_id = get_field(changeset, :body_id)
+    
+    if member_id != nil && Omscore.Members.get_body_membership(body_id, member_id) == nil do
+      add_error(changeset, :member_id, "You can only create payments for members of your own body")
+    else
+      changeset
+    end
+  end
+  defp validate_body_membership(changeset), do: changeset
+end

--- a/lib/omscore/finances/payment.ex
+++ b/lib/omscore/finances/payment.ex
@@ -10,8 +10,9 @@ defmodule Omscore.Finances.Payment do
     field :expires, :naive_datetime
     field :invoice_address, :string
     field :invoice_name, :string
-    field :member_id, :id
-    field :body_id, :id
+
+    belongs_to :body, Omscore.Core.Body
+    belongs_to :member, Omscore.Members.Member
 
     timestamps()
   end
@@ -22,12 +23,13 @@ defmodule Omscore.Finances.Payment do
     |> cast(attrs, [:amount, :currency, :expires, :invoice_name, :invoice_address, :comment])
     |> validate_required([:amount, :currency, :expires, :body_id])
     |> validate_body_membership()
+    |> validate_expiration()
   end
 
   defp validate_body_membership(%Ecto.Changeset{valid?: true} = changeset) do
     member_id = get_field(changeset, :member_id)
     body_id = get_field(changeset, :body_id)
-    
+
     if member_id != nil && Omscore.Members.get_body_membership(body_id, member_id) == nil do
       add_error(changeset, :member_id, "You can only create payments for members of your own body")
     else
@@ -35,4 +37,14 @@ defmodule Omscore.Finances.Payment do
     end
   end
   defp validate_body_membership(changeset), do: changeset
+
+
+  defp validate_expiration(%Ecto.Changeset{changes: %{expires: expires}} = changeset) when expires != nil do
+    if NaiveDateTime.compare(expires, NaiveDateTime.utc_now()) == :lt do
+      add_error(changeset, :expires, "Payments can not expire in the past")
+    else
+      changeset
+    end
+  end
+  defp validate_expiration(changeset), do: changeset
 end

--- a/lib/omscore/members/body_membership.ex
+++ b/lib/omscore/members/body_membership.ex
@@ -5,9 +5,6 @@ defmodule Omscore.Members.BodyMembership do
 
   schema "body_memberships" do
     field :comment, :string
-    field :fee, :decimal
-    field :fee_currency, :string
-    field :expiration, :naive_datetime
     field :has_expired, :boolean
     belongs_to :body, Omscore.Core.Body
     belongs_to :member, Omscore.Members.Member
@@ -18,18 +15,9 @@ defmodule Omscore.Members.BodyMembership do
   @doc false
   def changeset(body_membership, attrs) do
     body_membership
-    |> cast(attrs, [:comment, :fee, :fee_currency, :expiration])
+    |> cast(attrs, [:comment])
     |> validate_required([])
-    |> validate_expiration
     |> unique_constraint(:body_membership_unique, name: :body_memberships_body_id_member_id_index)
   end
 
-  defp validate_expiration(%Ecto.Changeset{changes: %{expiration: expiration}} = changeset) when expiration != nil do
-    if NaiveDateTime.compare(expiration, NaiveDateTime.utc_now()) == :lt do
-      add_error(changeset, :expiration, "Memberships can not expire in the past")
-    else
-      change(changeset, has_expired: false)
-    end
-  end
-  defp validate_expiration(changeset), do: changeset
 end

--- a/lib/omscore/members/member.ex
+++ b/lib/omscore/members/member.ex
@@ -20,6 +20,7 @@ defmodule Omscore.Members.Member do
     many_to_many :circles, Omscore.Core.Circle, join_through: Omscore.Members.CircleMembership, on_replace: :delete, on_delete: :delete_all
     has_many :circle_memberships, Omscore.Members.CircleMembership
     has_many :body_memberships, Omscore.Members.BodyMembership
+    has_many :payments, Omscore.Finances.Payment
 
     timestamps()
   end

--- a/lib/omscore_web/controllers/payment_controller.ex
+++ b/lib/omscore_web/controllers/payment_controller.ex
@@ -1,0 +1,71 @@
+defmodule OmscoreWeb.PaymentController do
+  use OmscoreWeb, :controller
+
+  alias Omscore.Finances
+  alias Omscore.Finances.Payment
+  alias Omscore.Core
+
+  action_fallback OmscoreWeb.FallbackController
+
+  def index(conn, params) do
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view", "payment") do
+      payments = Finances.list_payments(params)
+      render(conn, "index.json", payments: payments, filters: filters)
+    end
+  end
+
+  def index_bound(conn, params) do
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view", "payment") do
+      payments = Finances.list_bound_payments(conn.assigns.body.id, params)
+      render(conn, "index.json", payments: payments, filters: filters)
+    end
+  end
+
+  # If you want to show a payment which is not in the body through the bound request (where assigns.body will be set) you will get a 404
+  defp check_for_body(nil, _), do: {:ok}
+  defp check_for_body(body, payment) do 
+    if body.id == payment.body_id do
+      {:ok}
+    else
+      {:error, :not_found}
+    end
+  end
+
+  def show(conn, %{"payment_id" => id}) do
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view", "payment"),
+        payment <- Finances.get_payment!(id),
+        {:ok} <- check_for_body(conn.assigns[:body], payment) do
+      render(conn, "show.json", payment: payment, filters: filters)
+    end
+  end
+
+  def create(conn, %{"payment" => payment_params}) do
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "create", "payment"),
+         payment_params <- Core.apply_attribute_filters(payment_params, filters),
+         member <- Omscore.Members.get_member!(payment_params["member_id"]),
+         {:ok, %Payment{} = payment} <- Finances.create_payment(conn.assigns.body, member, payment_params) do
+      conn
+      |> put_status(:created)
+      |> render("show.json", payment: payment)
+    end
+  end
+
+
+  def update(conn, %{"payment_id" => id, "payment" => payment_params}) do
+    payment = Finances.get_payment!(id)
+
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "update", "payment"),
+         payment_params <- Core.apply_attribute_filters(payment_params, filters),
+         {:ok, %Payment{} = payment} <- Finances.update_payment(payment, payment_params) do
+      render(conn, "show.json", payment: payment)
+    end
+  end
+
+  def delete(conn, %{"payment_id" => id}) do
+    payment = Finances.get_payment!(id)
+    with {:ok, %Core.Permission{}} <- Core.search_permission_list(conn.assigns.permissions, "delete", "payment"),
+         {:ok, %Payment{}} <- Finances.delete_payment(payment) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/omscore_web/router.ex
+++ b/lib/omscore_web/router.ex
@@ -80,6 +80,11 @@ defmodule OmscoreWeb.Router do
     get "/backend_campaigns/:campaign_id", CampaignController, :show_full
     put "/backend_campaigns/:id", CampaignController, :update
     delete "/backend_campaigns/:id", CampaignController, :delete
+
+    get "/payments", PaymentController, :index
+    get "/payments/:payment_id", PaymentController, :show
+    put "/payments/:payment_id", PaymentController, :update
+    delete "/payments/:payment_id", PaymentController, :delete
   end
 
   # Operating on the member, permissions based on the bodies he is part in will be granted
@@ -133,5 +138,9 @@ defmodule OmscoreWeb.Router do
     get "/join_requests", JoinRequestController, :index
     get "/join_requests/:id", JoinRequestController, :show
     post "/join_requests/:id", JoinRequestController, :process
+
+    get "/payments", PaymentController, :index_bound
+    post "/payments", PaymentController, :create
+    get "/payments/:payment_id", PaymentController, :show
   end
 end

--- a/lib/omscore_web/views/body_membership_view.ex
+++ b/lib/omscore_web/views/body_membership_view.ex
@@ -26,9 +26,6 @@ defmodule OmscoreWeb.BodyMembershipView do
   def render("body_membership.json", %{body_membership: body_membership}) do
     %{id: body_membership.id,
       comment: body_membership.comment,
-      fee: body_membership.fee,
-      fee_currency: body_membership.fee_currency,
-      expiration: body_membership.expiration,
       has_expired: body_membership.has_expired,
       inserted_at: body_membership.inserted_at,
       member_id: body_membership.member_id,

--- a/lib/omscore_web/views/body_view.ex
+++ b/lib/omscore_web/views/body_view.ex
@@ -39,6 +39,7 @@ defmodule OmscoreWeb.BodyView do
       description: body.description,
       legacy_key: body.legacy_key,
       type: body.type,
+      pays_fees: body.pays_fees,
       shadow_circle_id: body.shadow_circle_id,
       circles: Helper.render_assoc_many(body.circles, OmscoreWeb.CircleView, "circle.json"),
       shadow_circle: Helper.render_assoc_one(body.shadow_circle, OmscoreWeb.CircleView, "circle.json")

--- a/lib/omscore_web/views/payment_view.ex
+++ b/lib/omscore_web/views/payment_view.ex
@@ -1,0 +1,33 @@
+defmodule OmscoreWeb.PaymentView do
+  use OmscoreWeb, :view
+  alias OmscoreWeb.PaymentView
+
+  def render("index.json", %{payments: payments, filters: filters}) do
+    data = payments
+    |> render_many(PaymentView, "payment.json")
+    |> Omscore.Core.apply_attribute_filters(filters)
+
+    %{success: true, data: data}
+  end
+
+  def render("show.json", %{payment: payment, filters: filters}) do
+    data = payment
+    |> render_one(PaymentView, "payment.json")
+    |> Omscore.Core.apply_attribute_filters(filters)
+
+    %{success: true, data: data}
+  end
+  def render("show.json", %{payment: payment}), do: render("show.json", %{payment: payment, filters: []})
+
+  def render("payment.json", %{payment: payment}) do
+    %{id: payment.id,
+      amount: payment.amount,
+      currency: payment.currency,
+      expires: payment.expires,
+      invoice_name: payment.invoice_name,
+      invoice_address: payment.invoice_address,
+      comment: payment.comment,
+      inserted_at: payment.inserted_at
+    }
+  end
+end

--- a/lib/omscore_web/views/payment_view.ex
+++ b/lib/omscore_web/views/payment_view.ex
@@ -1,6 +1,8 @@
 defmodule OmscoreWeb.PaymentView do
   use OmscoreWeb, :view
   alias OmscoreWeb.PaymentView
+  alias OmscoreWeb.Helper
+
 
   def render("index.json", %{payments: payments, filters: filters}) do
     data = payments
@@ -27,7 +29,11 @@ defmodule OmscoreWeb.PaymentView do
       invoice_name: payment.invoice_name,
       invoice_address: payment.invoice_address,
       comment: payment.comment,
-      inserted_at: payment.inserted_at
+      inserted_at: payment.inserted_at,
+      body_id: payment.body_id,
+      member_id: payment.member_id,
+      body: Helper.render_assoc_one(payment.body, OmscoreWeb.BodyView, "body.json"),
+      member: Helper.render_assoc_one(payment.member, OmscoreWeb.MemberView, "member.json")
     }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Omscore.Mixfile do
       aliases: aliases(),
       deps: deps(),
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test]
+      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test]
     ]
   end
 
@@ -61,7 +61,7 @@ defmodule Omscore.Mixfile do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      "test": ["ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
 end

--- a/priv/repo/migrations/20181121144717_create_payments.exs
+++ b/priv/repo/migrations/20181121144717_create_payments.exs
@@ -1,0 +1,21 @@
+defmodule Omscore.Repo.Migrations.CreatePayments do
+  use Ecto.Migration
+
+  def change do
+    create table(:payments) do
+      add :amount, :decimal, null: false
+      add :currency, :string, null: false
+      add :expires, :naive_datetime, null: false
+      add :invoice_name, :string
+      add :invoice_address, :string
+      add :comment, :string
+      add :member_id, references(:members, on_delete: :nilify_all)
+      add :body_id, references(:bodies, on_delete: :delete_all)
+
+      timestamps()
+    end
+
+    create index(:payments, [:member_id])
+    create index(:payments, [:body_id])
+  end
+end

--- a/priv/repo/migrations/20181122102722_remove_body_membership_fields.exs
+++ b/priv/repo/migrations/20181122102722_remove_body_membership_fields.exs
@@ -1,0 +1,11 @@
+defmodule Omscore.Repo.Migrations.RemoveBodyMembershipFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:body_memberships) do
+      remove :fee
+      remove :fee_currency
+      remove :expiration
+    end
+  end
+end

--- a/priv/repo/migrations/20181122102722_remove_body_membership_fields.exs
+++ b/priv/repo/migrations/20181122102722_remove_body_membership_fields.exs
@@ -2,10 +2,14 @@ defmodule Omscore.Repo.Migrations.RemoveBodyMembershipFields do
   use Ecto.Migration
 
   def change do
+    execute "UPDATE body_memberships SET has_expired=true"
+
     alter table(:body_memberships) do
       remove :fee
       remove :fee_currency
       remove :expiration
+      modify :has_expired, :boolean, default: true
+
     end
   end
 end

--- a/priv/repo/migrations/20181123125906_body_without_payments.exs
+++ b/priv/repo/migrations/20181123125906_body_without_payments.exs
@@ -1,0 +1,12 @@
+defmodule Omscore.Repo.Migrations.BodyWithoutPayments do
+  use Ecto.Migration
+
+  def change do
+    alter table(:bodies) do
+      add :pays_fees, :boolean, default: true, null: false
+    end
+
+    execute "UPDATE bodies SET pays_fees=false WHERE type NOT IN ('antenna', 'contact antenna', 'contact')"
+
+  end
+end

--- a/test/omscore/expire_tokens_test.exs
+++ b/test/omscore/expire_tokens_test.exs
@@ -215,7 +215,7 @@ defmodule Omscore.ExpireTokensTest do
 
   test "does not touch body memberships where the body doesn't have to pay fees" do
     member = member_fixture() |> Repo.preload([:user])
-    body = body_fixture(%{pays_fees: false})
+    body = body_fixture(%{pays_fees: false, type: "partner"})
     :ets.delete_all_objects(:saved_mail)
     assert {:ok, bm} = Omscore.Members.create_body_membership(body, member)
 

--- a/test/omscore/finances/finances_test.exs
+++ b/test/omscore/finances/finances_test.exs
@@ -103,13 +103,14 @@ defmodule Omscore.FinancesTest do
       assert %Ecto.Changeset{} = Finances.change_payment(payment)
     end
 
-    test "automatically sets the has_expired flag to false when a new payment was created" do
+    test "payment creation automatically sets expiry without having to wait for expire tokens worker" do
       member = member_fixture() |> Repo.preload([:user])
       body = body_fixture()
       :ets.delete_all_objects(:saved_mail)
 
       assert {:ok, bm} = Omscore.Members.create_body_membership(body, member)
       
+
       bm = bm
       |> Omscore.Members.BodyMembership.changeset(%{})
       |> Ecto.Changeset.change(has_expired: true)
@@ -117,124 +118,10 @@ defmodule Omscore.FinancesTest do
 
       payment_fixture(body, member)
 
-      Omscore.ExpireTokens.expire_memberships()
-
       bm = Repo.get!(Omscore.Members.BodyMembership, bm.id)
       assert bm.has_expired == false
       assert :ets.lookup(:saved_mail, member.user.email) == []
     end
 
-    test "automatically sets the has_expired flag to false when a payment's expiration was updated" do
-      member = member_fixture() |> Repo.preload([:user])
-      body = body_fixture()
-      :ets.delete_all_objects(:saved_mail)
-      assert {:ok, bm} = Omscore.Members.create_body_membership(body, member)
-      
-      payment = payment_fixture(body, member)
-      |> Payment.changeset(%{})
-      |> Ecto.Changeset.change(expires: Omscore.ecto_date_in_past(10))
-      |> Repo.update!
-
-      bm = bm
-      |> Omscore.Members.BodyMembership.changeset(%{})
-      |> Ecto.Changeset.change(has_expired: true)
-      |> Repo.update!
-
-      Finances.update_payment(payment, %{expires: Omscore.ecto_date_in_past(-10)})
-
-      Omscore.ExpireTokens.expire_memberships()
-
-      bm = Repo.get!(Omscore.Members.BodyMembership, bm.id)
-      assert bm.has_expired == false
-      assert :ets.lookup(:saved_mail, member.user.email) == []
-    end 
-
-    test "automatically sets the has_expired flag to true when membership expired" do
-      member = member_fixture() |> Repo.preload([:user])
-      body = body_fixture()
-      :ets.delete_all_objects(:saved_mail)
-      assert {:ok, bm} = Omscore.Members.create_body_membership(body, member)
-      
-      bm = bm
-      |> Omscore.Members.BodyMembership.changeset(%{})
-      |> Ecto.Changeset.change(has_expired: false)
-      |> Repo.update!
-
-      payment_fixture(body, member)
-      |> Payment.changeset(%{})
-      |> Ecto.Changeset.change(expires: Omscore.ecto_date_in_past(10))
-      |> Repo.update!
-
-      Omscore.ExpireTokens.expire_memberships()
-
-      bm = Repo.get!(Omscore.Members.BodyMembership, bm.id)
-      assert bm.has_expired == true
-
-      assert :ets.lookup(:saved_mail, member.user.email) != []
-    end
-
-    test "also automatically sets has_expired flag to true when no payments are present" do
-      member = member_fixture() |> Repo.preload([:user])
-      body = body_fixture()
-      :ets.delete_all_objects(:saved_mail)
-      assert {:ok, bm} = Omscore.Members.create_body_membership(body, member)
-
-      bm = bm
-      |> Omscore.Members.BodyMembership.changeset(%{})
-      |> Ecto.Changeset.change(has_expired: false)
-      |> Repo.update!
-
-      Omscore.ExpireTokens.expire_memberships()
-
-      bm = Repo.get!(Omscore.Members.BodyMembership, bm.id)
-      assert bm.has_expired == true
-
-      assert :ets.lookup(:saved_mail, member.user.email) != []
-    end
-
-    test "does not expire memberships where only some payments expired" do
-      member = member_fixture() |> Repo.preload([:user])
-      body = body_fixture()
-      :ets.delete_all_objects(:saved_mail)
-      assert {:ok, bm} = Omscore.Members.create_body_membership(body, member)
-      
-      bm = bm
-      |> Omscore.Members.BodyMembership.changeset(%{})
-      |> Ecto.Changeset.change(has_expired: false)
-      |> Repo.update!
-
-      payment_fixture(body, member)
-      |> Payment.changeset(%{})
-      |> Ecto.Changeset.change(expires: Omscore.ecto_date_in_past(10))
-      |> Repo.update!
-
-      payment_fixture(body, member)
-
-      Omscore.ExpireTokens.expire_memberships()
-
-      bm = Repo.get!(Omscore.Members.BodyMembership, bm.id)
-      assert bm.has_expired == false
-      assert :ets.lookup(:saved_mail, member.user.email) == []
-    end
-
-    test "does not expire nor send a mail when nothing happened" do
-      member = member_fixture() |> Repo.preload([:user])
-      body = body_fixture()
-      :ets.delete_all_objects(:saved_mail)
-      assert {:ok, bm} = Omscore.Members.create_body_membership(body, member)
-      
-      bm = bm
-      |> Omscore.Members.BodyMembership.changeset(%{})
-      |> Ecto.Changeset.change(has_expired: false)
-      |> Repo.update!
-
-      payment_fixture(body, member)
-      
-      Omscore.ExpireTokens.expire_memberships()
-
-      bm = Repo.get!(Omscore.Members.BodyMembership, bm.id)
-      assert bm.has_expired == false
-      assert :ets.lookup(:saved_mail, member.user.email) == []
-    end
   end
 end

--- a/test/omscore/finances/finances_test.exs
+++ b/test/omscore/finances/finances_test.exs
@@ -1,0 +1,99 @@
+defmodule Omscore.FinancesTest do
+  use Omscore.DataCase
+
+  alias Omscore.Finances
+
+  describe "payments" do
+    alias Omscore.Finances.Payment
+
+    @valid_attrs %{amount: "120.5", comment: "some comment", currency: "some currency", expires: ~N[2010-04-17 14:00:00.000000], invoice_address: "some invoice_address", invoice_name: "some invoice_name"}
+    @update_attrs %{amount: "456.7", comment: "some updated comment", currency: "some updated currency", expires: ~N[2011-05-18 15:01:01.000000], invoice_address: "some updated invoice_address", invoice_name: "some updated invoice_name"}
+    @invalid_attrs %{amount: nil, comment: nil, currency: nil, expires: nil, invoice_address: nil, invoice_name: nil}
+
+    test "list_payments/0 returns all payments" do
+      payment = payment_fixture()
+      assert Finances.list_payments() == [payment]
+    end
+
+    test "list_bound_payments/1 returns only bound payments" do
+      body = body_fixture()
+      payment = payment_fixture(body)
+      payment_fixture()
+      assert Finances.list_bound_payments(body.id) == [payment]
+    end
+
+    test "get_payment!/1 returns the payment with given id" do
+      payment = payment_fixture()
+      assert Finances.get_payment!(payment.id) == payment
+    end
+
+    test "create_payment/3 with valid data creates a payment" do
+      body = body_fixture()
+      member = member_fixture()
+
+      {:ok, _} = Omscore.Members.create_body_membership(body, member)
+
+      assert {:ok, %Payment{} = payment} = Finances.create_payment(body, member, @valid_attrs)
+      assert payment.amount == Decimal.new("120.5")
+      assert payment.comment == "some comment"
+      assert payment.currency == "some currency"
+      assert payment.expires == ~N[2010-04-17 14:00:00.000000]
+      assert payment.invoice_address == "some invoice_address"
+      assert payment.invoice_name == "some invoice_name"
+      assert payment.body_id == body.id
+      assert payment.member_id == member.id
+    end
+
+    test "create_payment/3 with invalid data returns error changeset" do
+      body = body_fixture()
+      member = member_fixture()
+
+      {:ok, _} = Omscore.Members.create_body_membership(body, member)
+
+      assert {:error, %Ecto.Changeset{}} = Finances.create_payment(body, member, @invalid_attrs)
+    end
+
+    test "create_payment/3 forbids creating a payment for a member which isn't in the body" do
+      body = body_fixture()
+      member = member_fixture()
+
+      assert {:error, _} = Finances.create_payment(body, member, @valid_attrs)
+    end
+
+    test "update_payment/2 with valid data updates the payment" do
+      payment = payment_fixture()
+      assert {:ok, payment} = Finances.update_payment(payment, @update_attrs)
+      assert %Payment{} = payment
+      assert payment.amount == Decimal.new("456.7")
+      assert payment.comment == "some updated comment"
+      assert payment.currency == "some updated currency"
+      assert payment.expires == ~N[2011-05-18 15:01:01.000000]
+      assert payment.invoice_address == "some updated invoice_address"
+      assert payment.invoice_name == "some updated invoice_name"
+    end
+
+    test "update_payment/2 with invalid data returns error changeset" do
+      payment = payment_fixture()
+      assert {:error, %Ecto.Changeset{}} = Finances.update_payment(payment, @invalid_attrs)
+      assert payment == Finances.get_payment!(payment.id)
+    end
+
+    test "update_payment/2 ignores updating body or member" do
+      payment = payment_fixture()
+      assert {:ok, payment} = Finances.update_payment(payment, %{body_id: -1, member_id: -1})
+      assert payment.body_id != -1
+      assert payment.member_id != -1
+    end
+
+    test "delete_payment/1 deletes the payment" do
+      payment = payment_fixture()
+      assert {:ok, %Payment{}} = Finances.delete_payment(payment)
+      assert_raise Ecto.NoResultsError, fn -> Finances.get_payment!(payment.id) end
+    end
+
+    test "change_payment/1 returns a payment changeset" do
+      payment = payment_fixture()
+      assert %Ecto.Changeset{} = Finances.change_payment(payment)
+    end
+  end
+end

--- a/test/omscore/members/members_test.exs
+++ b/test/omscore/members/members_test.exs
@@ -364,61 +364,6 @@ defmodule Omscore.MembersTest do
       assert {:ok, _} = Members.delete_body_membership(bm)
       assert nil == Members.get_body_membership(body, member)
     end
-
-    test "body membership has an expiration date and a fee" do
-      member = member_fixture()
-      body = body_fixture()
-      assert {:ok, bm} = Members.create_body_membership(body, member)
-
-      assert {:ok, bm} = Members.update_body_membership(bm, %{fee: 12.0, fee_currency: "euro", expiration: Omscore.ecto_date_in_past(-10)})
-      assert bm = Members.get_body_membership!(bm.id)
-      assert Decimal.equal?(bm.fee, 12)
-      assert bm.fee_currency == "euro"
-      assert bm.expiration
-      assert bm.has_expired == false
-    end
-
-    test "does not allow setting an expiration in the past" do
-      member = member_fixture()
-      body = body_fixture()
-      assert {:ok, bm} = Members.create_body_membership(body, member)
-      assert {:error, _bm} = Members.update_body_membership(bm, %{fee: 12.0, fee_currency: "euro", expiration: Omscore.ecto_date_in_past(10)})
-    end
-
-    test "automatically sets the has_expired flag to false when membership expired" do
-      member = member_fixture()
-      body = body_fixture()
-      assert {:ok, bm} = Members.create_body_membership(body, member)
-      
-      bm = bm
-      |> BodyMembership.changeset(%{})
-      |> Ecto.Changeset.change(expiration: Omscore.ecto_date_in_past(10), has_expired: false)
-      |> Repo.update!
-
-      Omscore.ExpireTokens.expire_memberships()
-
-      bm = Repo.get!(BodyMembership, bm.id)
-      assert bm.has_expired == true
-    end
-
-    test "sends a mail when membership expired" do
-      member = member_fixture() |> Repo.preload([:user])
-      body = body_fixture()
-      assert {:ok, bm} = Members.create_body_membership(body, member)
-      :ets.delete_all_objects(:saved_mail)
-
-      bm = bm
-      |> BodyMembership.changeset(%{})
-      |> Ecto.Changeset.change(expiration: Omscore.ecto_date_in_past(10), has_expired: false)
-      |> Repo.update!
-
-      Omscore.ExpireTokens.expire_memberships()
-
-      bm = Repo.get!(BodyMembership, bm.id)
-      assert bm.has_expired == true
-
-      assert :ets.lookup(:saved_mail, member.user.email) != []
-    end
   end
 
   describe "circle_memberships" do

--- a/test/omscore_web/controllers/body_controller_test.exs
+++ b/test/omscore_web/controllers/body_controller_test.exs
@@ -109,7 +109,7 @@ defmodule OmscoreWeb.BodyControllerTest do
     end
 
     test "rejects to unauthorized user", %{conn: conn, body: body} do
-      campaign = campaign_fixture(%{autojoin_body_id: body.id})
+      campaign_fixture(%{autojoin_body_id: body.id})
 
       %{token: token} = create_member_with_permissions([])
       conn = put_req_header(conn, "x-auth-token", token)

--- a/test/omscore_web/controllers/payment_controller_test.exs
+++ b/test/omscore_web/controllers/payment_controller_test.exs
@@ -63,6 +63,7 @@ defmodule OmscoreWeb.PaymentControllerTest do
       conn = get conn, payment_path(conn, :show, payment.id)
       assert res = json_response(conn, 200)["data"]
       assert res["id"] == payment.id
+      
     end
 
     test "shows bound payment", %{conn: conn} do

--- a/test/omscore_web/controllers/payment_controller_test.exs
+++ b/test/omscore_web/controllers/payment_controller_test.exs
@@ -1,0 +1,237 @@
+defmodule OmscoreWeb.PaymentControllerTest do
+  use OmscoreWeb.ConnCase
+
+  alias Omscore.Finances.Payment
+
+  @create_attrs %{amount: "120.5", comment: "some comment", currency: "some currency", expires: ~N[2010-04-17 14:00:00.000000], invoice_address: "some invoice_address", invoice_name: "some invoice_name"}
+  @update_attrs %{amount: "456.7", comment: "some updated comment", currency: "some updated currency", expires: ~N[2011-05-18 15:01:01.000000], invoice_address: "some updated invoice_address", invoice_name: "some updated invoice_name"}
+  @invalid_attrs %{amount: nil, comment: nil, currency: nil, expires: nil, invoice_address: nil, invoice_name: nil}
+
+  def fixture(:payment) do
+    payment_fixture(@create_attrs)
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all payments", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "view", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      conn = get conn, payment_path(conn, :index)
+      assert json_response(conn, 200)["data"] == []
+    end
+
+    test "lists all bound payments", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "view", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      body = body_fixture()
+
+      conn = get conn, body_payment_path(conn, :index_bound, body.id)
+      assert json_response(conn, 200)["data"] == []
+    end
+
+    test "rejects to unauthorized member", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      conn = get conn, payment_path(conn, :index)
+      assert json_response(conn, 403)
+    end
+
+    test "bound rejects to unauthorized member", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      body = body_fixture()
+
+      conn = get conn, body_payment_path(conn, :index_bound, body.id)
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "show" do
+    test "shows payment", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "view", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      payment = payment_fixture()
+
+      conn = get conn, payment_path(conn, :show, payment.id)
+      assert res = json_response(conn, 200)["data"]
+      assert res["id"] == payment.id
+    end
+
+    test "shows bound payment", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "view", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      body = body_fixture()
+      payment = payment_fixture(body)
+
+      conn = get conn, body_payment_path(conn, :show, body.id, payment.id)
+      assert res = json_response(conn, 200)["data"]
+      assert res["id"] == payment.id
+    end
+
+    test "bound only shows bound payments", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "view", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      body = body_fixture()
+      payment = payment_fixture()
+
+      conn = get conn, body_payment_path(conn, :show, body.id, payment.id)
+      assert json_response(conn, 404)
+    end
+
+    test "rejects to unauthorized user", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      payment = payment_fixture()
+
+      conn = get conn, payment_path(conn, :show, payment.id)
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "create payment" do
+    test "renders payment when data is valid", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "create", object: "payment"}, %{action: "view", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      body = body_fixture()
+      member = member_fixture()
+      {:ok, _} = Omscore.Members.create_body_membership(body, member)
+
+      conn = post conn, body_payment_path(conn, :create, body.id), payment: @create_attrs |> Map.put(:member_id, member.id)
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = conn
+      |> recycle()
+      |> put_req_header("x-auth-token", token)
+
+      conn = get conn, payment_path(conn, :show, id)
+      assert json_response(conn, 200)["data"] |> map_inclusion(%{
+        "id" => id,
+        "amount" => "120.5",
+        "comment" => "some comment",
+        "currency" => "some currency",
+        "invoice_address" => "some invoice_address",
+        "invoice_name" => "some invoice_name"})
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "create", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      body = body_fixture()
+      member = member_fixture()
+      {:ok, _} = Omscore.Members.create_body_membership(body, member)
+
+      conn = post conn, body_payment_path(conn, :create, body.id), payment: @invalid_attrs |> Map.put(:member_id, member.id)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "renders errors when member is invalid", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "create", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      body = body_fixture()
+      member = member_fixture()
+
+      conn = post conn, body_payment_path(conn, :create, body.id), payment: @create_attrs |> Map.put(:member_id, member.id)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "rejects to unauthorized user", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      body = body_fixture()
+      member = member_fixture()
+      {:ok, _} = Omscore.Members.create_body_membership(body, member)
+
+      conn = post conn, body_payment_path(conn, :create, body.id), payment: @create_attrs |> Map.put(:member_id, member.id)
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "update payment" do
+    setup [:create_payment]
+
+    test "renders payment when data is valid", %{conn: conn, payment: %Payment{id: id} = payment} do
+      %{token: token} = create_member_with_permissions([%{action: "update", object: "payment"}, %{action: "view", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      conn = put conn, payment_path(conn, :update, payment), payment: @update_attrs
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = conn
+      |> recycle()
+      |> put_req_header("x-auth-token", token)
+
+      conn = get conn, payment_path(conn, :show, id)
+      assert json_response(conn, 200)["data"] |> map_inclusion(%{
+        "id" => id,
+        "amount" => "456.7",
+        "comment" => "some updated comment",
+        "currency" => "some updated currency",
+        "invoice_address" => "some updated invoice_address",
+        "invoice_name" => "some updated invoice_name"})
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, payment: payment} do
+      %{token: token} = create_member_with_permissions([%{action: "update", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      conn = put conn, payment_path(conn, :update, payment), payment: @invalid_attrs
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
+    test "rejects to unauthorized user", %{conn: conn, payment: payment} do
+      %{token: token} = create_member_with_permissions([])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      conn = put conn, payment_path(conn, :update, payment), payment: @update_attrs
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "delete payment" do
+    setup [:create_payment]
+
+    test "deletes chosen payment", %{conn: conn, payment: payment} do
+      %{token: token} = create_member_with_permissions([%{action: "delete", object: "payment"}, %{action: "view", object: "payment"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      conn = delete conn, payment_path(conn, :delete, payment)
+      assert response(conn, 204)
+
+      conn = conn
+      |> recycle()
+      |> put_req_header("x-auth-token", token)
+
+      assert_error_sent 404, fn ->
+        get conn, payment_path(conn, :show, payment)
+      end
+    end
+
+    test "rejects to unauthorized user", %{conn: conn, payment: payment} do
+      %{token: token} = create_member_with_permissions([])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      conn = delete conn, payment_path(conn, :delete, payment)
+      assert response(conn, 403)
+    end
+  end
+
+  defp create_payment(_) do
+    payment = fixture(:payment)
+    {:ok, payment: payment}
+  end
+end

--- a/test/omscore_web/controllers/payment_controller_test.exs
+++ b/test/omscore_web/controllers/payment_controller_test.exs
@@ -3,8 +3,8 @@ defmodule OmscoreWeb.PaymentControllerTest do
 
   alias Omscore.Finances.Payment
 
-  @create_attrs %{amount: "120.5", comment: "some comment", currency: "some currency", expires: ~N[2010-04-17 14:00:00.000000], invoice_address: "some invoice_address", invoice_name: "some invoice_name"}
-  @update_attrs %{amount: "456.7", comment: "some updated comment", currency: "some updated currency", expires: ~N[2011-05-18 15:01:01.000000], invoice_address: "some updated invoice_address", invoice_name: "some updated invoice_name"}
+  @create_attrs %{amount: "120.5", comment: "some comment", currency: "some currency", expires: ~N[3010-04-17 14:00:00.000000], invoice_address: "some invoice_address", invoice_name: "some invoice_name"}
+  @update_attrs %{amount: "456.7", comment: "some updated comment", currency: "some updated currency", expires: ~N[3011-05-18 15:01:01.000000], invoice_address: "some updated invoice_address", invoice_name: "some updated invoice_name"}
   @invalid_attrs %{amount: nil, comment: nil, currency: nil, expires: nil, invoice_address: nil, invoice_name: nil}
 
   def fixture(:payment) do

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -202,6 +202,26 @@ defmodule OmscoreWeb.Fixtures do
     %{reset: reset, confirmation: confirmation, refresh: refresh, submission: submission, user: user}
   end
 
+  @valid_payment_attrs %{amount: "120.5", comment: "some comment", currency: "euro", expires: ~N[2010-04-17 14:00:00.000000], invoice_address: "some invoice_address", invoice_name: "some invoice_name"}
+  def payment_fixture(%Omscore.Core.Body{} = body, %Omscore.Members.Member{} = member, attrs) do
+    
+    attrs = attrs
+    |> Enum.into(@valid_payment_attrs)  
+
+    {:ok, payment} = Omscore.Finances.create_payment(body, member, attrs)
+    payment
+  end
+  def payment_fixture(%Omscore.Core.Body{} = body, %Omscore.Members.Member{} = member), do: payment_fixture(body, member, %{})
+  def payment_fixture(%Omscore.Core.Body{} = body, attrs) do
+    member = member_fixture()
+    {:ok, _} = Omscore.Members.create_body_membership(body, member)
+
+    payment_fixture(body, member, attrs)
+  end
+  def payment_fixture(%Omscore.Core.Body{} = body), do: payment_fixture(body, %{})
+  def payment_fixture(attrs), do: payment_fixture(body_fixture(), attrs)
+  def payment_fixture(), do: payment_fixture(%{})
+
   def map_inclusion(map_to_check, should_be_in_there) when is_map(should_be_in_there) do
     should_be_in_there
     |> Map.keys

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -202,13 +202,13 @@ defmodule OmscoreWeb.Fixtures do
     %{reset: reset, confirmation: confirmation, refresh: refresh, submission: submission, user: user}
   end
 
-  @valid_payment_attrs %{amount: "120.5", comment: "some comment", currency: "euro", expires: ~N[2010-04-17 14:00:00.000000], invoice_address: "some invoice_address", invoice_name: "some invoice_name"}
+  @valid_payment_attrs %{amount: "120.5", comment: "some comment", currency: "euro", expires: ~N[3010-04-17 14:00:00.000000], invoice_address: "some invoice_address", invoice_name: "some invoice_name"}
   def payment_fixture(%Omscore.Core.Body{} = body, %Omscore.Members.Member{} = member, attrs) do
     
     attrs = attrs
     |> Enum.into(@valid_payment_attrs)  
 
-    {:ok, payment} = Omscore.Finances.create_payment(body, member, attrs)
+    {:ok, payment} = Omscore.Finances.create_payment(body, member, attrs) 
     payment
   end
   def payment_fixture(%Omscore.Core.Body{} = body, %Omscore.Members.Member{} = member), do: payment_fixture(body, member, %{})

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -103,7 +103,7 @@ defmodule OmscoreWeb.Fixtures do
     circle
   end
 
-  @body_attrs %{address: "some address", description: "some description", email: "some email", legacy_key: "some legacy_key", name: "some name", phone: "some phone", type: "antenna"}
+  @body_attrs %{address: "some address", description: "some description", email: "some email", legacy_key: "some legacy_key", name: "some name", phone: "some phone", type: "antenna", pays_fees: true}
   def body_fixture(attrs \\ %{}) do
     {:ok, body} =
       attrs


### PR DESCRIPTION
This creates an API for fee payments as we discussed it in slack. Expiry information on body memberships is currently not solved with a virtual boolean but a normal one which should increase GET performance.