### PR TITLE
Added request to get members which have a certain permission in a body

### DIFF
--- a/lib/omscore/core/core.ex
+++ b/lib/omscore/core/core.ex
@@ -259,6 +259,16 @@ defmodule Omscore.Core do
     |> Repo.all
   end
 
+  # Lists all bound circles which have a certain permission directly or indirectly attached.
+  # This function is rather unperformant with big numbers of circles...
+  def list_bound_circles_with_permission(%Body{} = body, action, object), do: list_bound_circles_with_permission(body.id, action, object)
+  def list_bound_circles_with_permission(body_id, action, object) do
+    from(u in Circle, where: u.body_id == ^body_id)
+    |> Repo.all
+    |> Enum.map(fn(circle) -> Map.put(circle, :all_permissions, get_permissions_recursive(circle)) end)
+    |> Enum.filter(fn(circle) -> Enum.any?(circle.all_permissions, fn(x) -> x.action == action and x.object == object end) end)
+  end
+
   # Get a single circle
   def get_circle!(id), do: Repo.get!(Circle, id) |> Repo.preload([:permissions, :child_circles, :parent_circle])
   def get_circle(id), do: Repo.get(Circle, id)

--- a/lib/omscore_web/controllers/body_controller.ex
+++ b/lib/omscore_web/controllers/body_controller.ex
@@ -57,6 +57,14 @@ defmodule OmscoreWeb.BodyController do
     end
   end
 
+  # When called with holds_permission parameter, only returns those members who got that permission locally. (Actually received it in the body)
+  def show_members(conn, %{"holds_permission" => %{"action" => action, "object" => object}}) do
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view_members", "body"),
+        body_memberships = Members.list_body_memberships_with_permission(conn.assigns.body, action, object) do
+      render(conn, OmscoreWeb.BodyMembershipView, "index.json", body_memberships: body_memberships, filters: filters)
+    end
+  end
+
   def show_members(conn, params) do
     body_memberships = Members.list_body_memberships(conn.assigns.body, params)
     with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view_members", "body") do

--- a/lib/omscore_web/controllers/circle_controller.ex
+++ b/lib/omscore_web/controllers/circle_controller.ex
@@ -164,6 +164,13 @@ defmodule OmscoreWeb.CircleController do
     end
   end
 
+  # Different request when filtering for holds_permissions
+  def index_bound(conn, %{"holds_permission" => %{"action" => action, "object" => object}}) do
+    with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view", "circle") do
+      circles = Core.list_bound_circles_with_permission(conn.assigns.body, action, object)
+      render(conn, "index.json", circles: circles, filters: filters)
+    end
+  end
 
   def index_bound(conn, params) do
     with {:ok, %Core.Permission{filters: filters}} <- Core.search_permission_list(conn.assigns.permissions, "view", "circle") do

--- a/test/omscore/core/core_test.exs
+++ b/test/omscore/core/core_test.exs
@@ -326,6 +326,24 @@ defmodule Omscore.CoreTest do
       assert Enum.any?(res, fn(x) -> x.id == circle2.id end)
     end
 
+    test "list_bound_circles_with_permission/3 returns all bound circles which have a certain permission" do
+      circle1 = circle_fixture()
+      body = body_fixture()
+      circle2 = bound_circle_fixture(body)
+      circle3 = bound_circle_fixture(body)
+      circle4 = bound_circle_fixture(body)
+      Core.put_child_circles(circle1, [circle2])
+      permission = permission_fixture(%{action: "approve", object: "epm_applications"})
+      Core.put_circle_permissions(circle1, [permission])
+      Core.put_circle_permissions(circle4, [permission])
+
+      res = Core.list_bound_circles_with_permission(body, "approve", "epm_applications")
+      assert !Enum.any?(res, fn(x) -> x.id == circle1.id end)
+      assert Enum.any?(res, fn(x) -> x.id == circle2.id end)
+      assert !Enum.any?(res, fn(x) -> x.id == circle3.id end)
+      assert Enum.any?(res, fn(x) -> x.id == circle4.id end)
+    end
+
     test "get_circle!/1 returns the circle with given id" do
       circle = circle_fixture()
       assert circle = Core.get_circle!(circle.id)

--- a/test/omscore/members/members_test.exs
+++ b/test/omscore/members/members_test.exs
@@ -347,6 +347,24 @@ defmodule Omscore.MembersTest do
       assert !Enum.any?(res, fn(x) -> x.member_id == member2.id end)
     end
 
+    test "list_body_memberships_with_permission/3 lists all members who have a certain permission in the body" do
+      member1 = member_fixture(%{first_name: "quiesel"})
+      member2 = member_fixture(%{first_name: "weasel"})
+      body = body_fixture()
+      circle = bound_circle_fixture(body)
+      permission = permission_fixture(%{action: "approve", object: "epm_application"})
+      assert {:ok, _} = Members.create_body_membership(body, member1)
+      assert {:ok, _} = Members.create_body_membership(body, member2)
+      assert {:ok, _} = Members.create_circle_membership(circle, member1)
+      assert {:ok, _} = Omscore.Core.put_circle_permissions(circle, [permission])
+      %{member: member3} = create_member_with_permissions(%{action: "approve", object: "epm_application"})
+
+      res = Members.list_body_memberships_with_permission(body, "approve", "epm_application")
+      assert Enum.any?(res, fn(x) -> x.member_id == member1.id end)
+      assert !Enum.any?(res, fn(x) -> x.member_id == member2.id end)
+      assert !Enum.any?(res, fn(x) -> x.member_id == member3.id end)
+    end
+
     test "update_body_membership/1 updates a body membership" do
       member = member_fixture()
       body = body_fixture()


### PR DESCRIPTION
/bodies/:id/circles and /bodies/:id/members now allow passing a ?holds_permission query parameter to only return members which hold that permission.