### PR TITLE
Fixes filter syntax

### DIFF
--- a/lib/omscore/members/members.ex
+++ b/lib/omscore/members/members.ex
@@ -93,13 +93,14 @@ defmodule Omscore.Members do
 
   alias Omscore.Members.JoinRequest
 
-  defp filter_approved_joinrequests(query, params) do
-    case Map.get(params, "filter[approved]") do
+  defp filter_approved_joinrequests(query, %{"filter" => filters}) do
+    case Map.get(filters, "approved") do
       "true" -> from(q in query, where: q.approved == true)
       "false" -> from(q in query, where: q.approved == false)
       _ -> query
     end
   end
+  defp filter_approved_joinrequests(query, _), do: query
 
   # Get all join requests for a body
   def list_join_requests(%Omscore.Core.Body{} = body, params \\ %{}) do

--- a/lib/omscore_web/helper.ex
+++ b/lib/omscore_web/helper.ex
@@ -52,16 +52,16 @@ defmodule OmscoreWeb.Helper do
 
   # Filters the result based attribute-value filters and not a fuzzy search
   # It checks for occurances like filter.attribute=value in params
-  def filter(query, params, [attribute | remaining_attributes]) do
-    key = "filter[" <> Atom.to_string(attribute) <> "]"
-    query = if Map.has_key?(params, key) do
-      querystring = params[key]
+  def filter(query, %{"filter" => filters}, [attribute | remaining_attributes]) do
+    key = Atom.to_string(attribute)
+    query = if Map.has_key?(filters, key) do
+      querystring = filters[key]
       from q in query, where: ilike(field(q, ^attribute), ^"#{querystring}")
     else
       query
     end
-    filter(query, params, remaining_attributes)
+    filter(query, %{"filter" => filters}, remaining_attributes)
   end
-  def filter(query, _params, []), do: query
+  def filter(query, _params, _attributes), do: query
 
 end

--- a/test/omscore/helpers_test.exs
+++ b/test/omscore/helpers_test.exs
@@ -148,7 +148,7 @@ defmodule Omscore.HelpersTest do
       member5 = member_fixture(%{first_name: "antihans"})
 
       res = from(u in Members.Member)
-      |> Helper.filter(%{"filter[first_name]" => "hans"}, Omscore.Members.Member.__schema__(:fields))
+      |> Helper.filter(%{"filter" => %{"first_name" => "hans"}}, Omscore.Members.Member.__schema__(:fields))
       |> Repo.all
 
       assert Enum.any?(res, fn(x) -> x.id == member1.id end)
@@ -166,7 +166,7 @@ defmodule Omscore.HelpersTest do
       member5 = member_fixture(%{first_name: "antihans"})
 
       res = from(u in Members.Member)
-      |> Helper.filter(%{"filter[first_name]" => "hans", "filter.__meta__" => "'; OR TRUE"}, Omscore.Members.Member.__schema__(:fields))
+      |> Helper.filter(%{"filter" => %{"first_name" => "hans", "filter.__meta__" => "'; OR TRUE"}}, Omscore.Members.Member.__schema__(:fields))
       |> Repo.all
 
       assert Enum.any?(res, fn(x) -> x.id == member1.id end)

--- a/test/omscore/members/members_test.exs
+++ b/test/omscore/members/members_test.exs
@@ -208,13 +208,13 @@ defmodule Omscore.MembersTest do
     test "list_join_requests/2 filters for open join requests" do
       {join_request, body, _member} = join_request_fixture()
 
-      assert Members.list_join_requests(body, %{"filter[approved]" => "true"}) == []
-      assert Members.list_join_requests(body, %{"filter[approved]" => "false"}) != []
+      assert Members.list_join_requests(body, %{"filter" => %{"approved" => "true"}}) == []
+      assert Members.list_join_requests(body, %{"filter" => %{"approved" => "false"}}) != []
 
       assert {:ok, _body_membership} = Members.approve_join_request(join_request)
 
-      assert Members.list_join_requests(body, %{"filter[approved]" => "true"}) != []
-      assert Members.list_join_requests(body, %{"filter[approved]" => "false"}) == []
+      assert Members.list_join_requests(body, %{"filter" => %{"approved" => "true"}}) != []
+      assert Members.list_join_requests(body, %{"filter" => %{"approved" => "false"}}) == []
     end
 
 

--- a/test/omscore_web/controllers/body_controller_test.exs
+++ b/test/omscore_web/controllers/body_controller_test.exs
@@ -89,7 +89,7 @@ defmodule OmscoreWeb.BodyControllerTest do
 
       create_many_bodies(0..10)
 
-      conn = get conn, body_path(conn, :index), [{"filter[name]", "some really exotic query that definitely doesn't match any member at all"}]
+      conn = get conn, body_path(conn, :index), [{"filter", %{"name" => "some really exotic query that definitely doesn't match any member at all"}}]
       assert json_response(conn, 200)["data"] == []
     end
   end


### PR DESCRIPTION
Previously filters didn't work because I didn't assume automated deconstruction somewhere in phoenix query parsing, this should be fixed now.