### PR TITLE
Fixed lowercase email problem

### DIFF
--- a/lib/omscore/auth/auth.ex
+++ b/lib/omscore/auth/auth.ex
@@ -16,7 +16,10 @@ defmodule Omscore.Auth do
 
   def get_user!(id), do: Repo.get!(User, id)
 
-  def get_user_by_email!(email), do: Repo.get_by!(User, email: String.downcase(email))
+  def get_user_by_email!(email) do
+    Repo.one!(from(u in User, where: fragment("lower(?)", u.email) == ^String.downcase(email)))
+  end
+
   def get_user_by_member_id!(member_id) when is_binary(member_id) do
     {member_id, ""} = Integer.parse(member_id)
     get_user_by_member_id!(member_id)

--- a/lib/omscore/auth/auth.ex
+++ b/lib/omscore/auth/auth.ex
@@ -160,7 +160,7 @@ defmodule Omscore.Auth do
   # Fetch a user from DB
   def authenticate_user(username, plain_text_password) do
     username_lowercase = String.downcase(username)
-    query = from u in User, where: u.name == ^username or u.email == ^username_lowercase
+    query = from u in User, where: u.name == ^username or fragment("lower(?)", u.email) == ^username_lowercase
 
     with user <- Repo.one(query),
       {:ok, _user} <- check_password(user, plain_text_password),

--- a/test/omscore/auth/auth_test.exs
+++ b/test/omscore/auth/auth_test.exs
@@ -163,8 +163,15 @@ defmodule Omscore.AuthTest do
     end
 
     test "login also works with case-mismatch on email" do
-      user_fixture()
+      user = user_fixture()
       assert {:ok, _user, _access, _refresh} = Omscore.Auth.login_user("SOME@EMAIL.com", "some password")
+
+      user = user
+      |> Auth.User.changeset(%{})
+      |> Ecto.Changeset.force_change(:email, "SOME_WEIRD@email.com")
+      |> Repo.update!
+
+      assert {:ok, _user, _access, _refresh} = Omscore.Auth.login_user("some_weird@email.com", "some password")
     end
 
     test "refute bad credentials" do

--- a/test/omscore/auth/auth_test.exs
+++ b/test/omscore/auth/auth_test.exs
@@ -32,6 +32,17 @@ defmodule Omscore.AuthTest do
       assert Auth.get_user_by_email!("SOME_WEIRD@email.com")
     end
 
+    test "get_user_by_email!/1 works with upper-case stored emails" do
+      user = user_fixture(%{email: "SOME_WEIRD@email.com"})
+      user = user
+      |> Auth.User.changeset(%{})
+      |> Ecto.Changeset.force_change(:email, "SOME_WEIRD@email.com")
+      |> Repo.update!
+
+      assert Auth.get_user_by_email!("SOME_WEIRD@email.com")
+      assert Auth.get_user_by_email!("some_weird@email.com")
+    end
+
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Auth.create_user(@valid_attrs)
       assert user.email == "some@email.com"


### PR DESCRIPTION
Uppercase-Emails in the db can not log in/reset pw because of a bug in email fetching