### PR TITLE
Setting user.member_id on create_member_in_body

### DIFF
--- a/lib/omscore/auth/user.ex
+++ b/lib/omscore/auth/user.ex
@@ -9,7 +9,8 @@ defmodule Omscore.Auth.User do
     field :password, :string
     field :active, :boolean
     field :superadmin, :boolean
-    field :member_id, :integer
+
+    belongs_to :member, Omscore.Members.Member
 
     timestamps()
   end

--- a/lib/omscore/members/members.ex
+++ b/lib/omscore/members/members.ex
@@ -55,7 +55,8 @@ defmodule Omscore.Members do
            member_params <- Map.put(member_params, "user_id", user.id),
            {:ok, member} <- Omscore.Members.create_member(member_params),
            {:ok, %Omscore.Members.BodyMembership{}} <- Omscore.Members.create_body_membership(body, member),
-           {:ok, member} <- Omscore.Members.update_member(member, %{primary_body_id: body.id}) do
+           {:ok, member} <- Omscore.Members.update_member(member, %{primary_body_id: body.id}),
+           {:ok, _} <- Omscore.Auth.update_user_member_id(user, member.id) do
         # Then send him a mail that everything went well
         Omscore.Interfaces.Mail.send_mail(user.email, "welcome", %{body_name: body.name, email: user.email})
         {:ok, member}

--- a/test/omscore/members/members_test.exs
+++ b/test/omscore/members/members_test.exs
@@ -70,6 +70,8 @@ defmodule Omscore.MembersTest do
       assert member |> map_inclusion(Map.delete(@valid_attrs, :user_id))
       assert Members.get_body_membership(body, member)
       assert member.primary_body_id == body.id
+      assert user.member_id == member.id
+      assert member.user_id == user.id
 
       assert :ets.lookup(:saved_mail, @valid_user_attrs.email) != []
     end


### PR DESCRIPTION
I found another problem with create_member_in_body - it forgets to set user.member_id
