### PR TITLE
Added third scope: join requests

### DIFF
--- a/lib/omscore/core/core.ex
+++ b/lib/omscore/core/core.ex
@@ -113,7 +113,14 @@ defmodule Omscore.Core do
   defp merge_permissions(a, b) do
     filters = intersect_filters(a.filters, b.filters)
 
-    res = if a.scope == "global" do
+    scopes = Omscore.Core.Permission.scopes
+    # We should be able to rely on scopes always being in the scopes array
+    # If not, <= comparison will choose the non-nil value
+    idx_a = Enum.find_index(scopes, fn(x) -> x == a.scope end)
+    idx_b = Enum.find_index(scopes, fn(x) -> x == b.scope end)
+
+    # The scope with the lowest index is the higher one
+    res = if idx_a <= idx_b do
       a
     else
       b

--- a/lib/omscore/core/permission.ex
+++ b/lib/omscore/core/permission.ex
@@ -2,6 +2,8 @@ defmodule Omscore.Core.Permission do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @scopes ["global", "local", "join_request"]
+  def scopes(), do: @scopes
 
   schema "permissions" do
     field :action, :string
@@ -22,7 +24,7 @@ defmodule Omscore.Core.Permission do
     |> cast(attrs, [:scope, :action, :object, :description, :always_assigned])
     |> cast_embed(:filters)
     |> validate_required([:scope, :action, :object])
-    |> validate_inclusion(:scope, ["global", "local"], message: "must be either global or local")
+    |> validate_inclusion(:scope, @scopes, message: "must be either global, local or join_request")
     |> validate_format(:scope, ~r/^[^:]*$/, message: "Cannot contain colons")
     |> validate_format(:action, ~r/^[^:]*$/, message: "Cannot contain colons")
     |> validate_format(:object, ~r/^[^:]*$/, message: "Cannot contain colons")

--- a/lib/omscore/members/members.ex
+++ b/lib/omscore/members/members.ex
@@ -106,10 +106,10 @@ defmodule Omscore.Members do
   # Get all local permissions that the user has through his membership in the body
   def get_local_permissions(%Member{} = member, %Omscore.Core.Body{} = body) do
     member
-    |> list_bound_circle_memberships(body)                  # Get all circle memberships of the member in that body
+    |> list_bound_circle_memberships(body)            # Get all circle memberships of the member in that body
     |> Enum.map(fn(x) -> x.circle end)                # Strip the circle_membership part
     |> Omscore.Core.get_permissions_recursive()       # Gather all permissions on any of the circles
-    |> Omscore.Core.reduce_permission_list()          # Remove duplicates and overwrite local permissions with global permission, thus no need to filter before
+    #|> Omscore.Core.reduce_permission_list()          # Remove duplicates and overwrite local permissions with global permission, thus no need to filter before
   end
 
   # A bit of a lazy implementation of a get all permissions from the body plus all global ones


### PR DESCRIPTION
Permissions which are scoped "join_request" are now applied when accessing a member who filed a join request. This way, we can add join_request:view:members so board members can see who applied to their local, but not yet have the full board power over that account.