### PR TITLE
Allow passing multiple filter values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,25 @@
+## [0.3.2](https://github.com/AEGEE/oms-docker/compare/0.3.1...0.3.2) (2019-11-11)
+
+
+### Bug Fixes
+
+* **bodies:** fixed deprecation warning in route ([1f89907](https://github.com/AEGEE/oms-docker/commit/1f89907))
+* **general:** allow passing multiple filter values ([f8b30f0](https://github.com/AEGEE/oms-docker/commit/f8b30f0))
+* **test:** added tests for filters as arrays ([4ba0048](https://github.com/AEGEE/oms-docker/commit/4ba0048))
+
+
+
 ## [0.3.1](https://github.com/AEGEE/oms-docker/compare/0.3.0...0.3.1) (2019-11-08)
 
 
 ### Bug Fixes
 
-* **docker:** fixed docker tag generation in docker-compose ([1490708](https://github.com/AEGEE/oms-docker/commit/14907082e94bfc574b4a74352cb142e552ad624e))
+* **docker:** fixed docker tag generation in docker-compose ([1490708](https://github.com/AEGEE/oms-docker/commit/1490708))
 
 
 ### Features
 
-* **general:** switched to CircleCI from Travis. Fixes MEMB-678 ([4f41c87](https://github.com/AEGEE/oms-docker/commit/4f41c870c912e91dfe01206616c688b3cc5b9345))
+* **general:** switched to CircleCI from Travis. Fixes MEMB-678 ([4f41c87](https://github.com/AEGEE/oms-docker/commit/4f41c87))
 
 
 
@@ -17,31 +28,31 @@
 
 ### Bug Fixes
 
-* **healthcheck:** add port number, and curl ([57f741d](https://github.com/AEGEE/oms-docker/commit/57f741d1e022016568c33482bfa46f3c0887bd64))
-* deps.get does some magic, idk ([985f3ab](https://github.com/AEGEE/oms-docker/commit/985f3abc5d1f46765736d929f2700e4359b28145))
-* forgot to update name of environment ([5c060df](https://github.com/AEGEE/oms-docker/commit/5c060dfcc6e49f5a66e4c382dd5dcb86c39450aa))
-* **CI:** add .dev compose file to the CI ([cc329a8](https://github.com/AEGEE/oms-docker/commit/cc329a8c8f9198d35803fcdb04281133d04ca04e))
-* **CI:** env variables not set ([02f50f1](https://github.com/AEGEE/oms-docker/commit/02f50f1085ab29a6d424d9e6463cf04bce647a4d))
-* **CI:** need a docker command ([e06b581](https://github.com/AEGEE/oms-docker/commit/e06b5811c7092edce4fab1d046baace8e45c194f))
-* **CI:** the proper CMD breaks CI and I don't care ([c390fb3](https://github.com/AEGEE/oms-docker/commit/c390fb3d71f6318f13fb61b20c7166e2338c4203))
-* **docker:** avoid overwriting of folder ([f50d7a3](https://github.com/AEGEE/oms-docker/commit/f50d7a3c2ebe166c7d06d6dde8e65350bed93fcd))
-* **docker:** do not ignore files we need to COPY ([3205790](https://github.com/AEGEE/oms-docker/commit/32057906ea8a26a1cdf250bfe47596c3530cd194))
-* have to go around secrets ([d0b790f](https://github.com/AEGEE/oms-docker/commit/d0b790f4642e9f04d334e4922fd1ee97453f7d37))
+* **healthcheck:** add port number, and curl ([57f741d](https://github.com/AEGEE/oms-docker/commit/57f741d))
+* deps.get does some magic, idk ([985f3ab](https://github.com/AEGEE/oms-docker/commit/985f3ab))
+* forgot to update name of environment ([5c060df](https://github.com/AEGEE/oms-docker/commit/5c060df))
+* **CI:** add .dev compose file to the CI ([cc329a8](https://github.com/AEGEE/oms-docker/commit/cc329a8))
+* **CI:** env variables not set ([02f50f1](https://github.com/AEGEE/oms-docker/commit/02f50f1))
+* **CI:** need a docker command ([e06b581](https://github.com/AEGEE/oms-docker/commit/e06b581))
+* **CI:** the proper CMD breaks CI and I don't care ([c390fb3](https://github.com/AEGEE/oms-docker/commit/c390fb3))
+* **docker:** avoid overwriting of folder ([f50d7a3](https://github.com/AEGEE/oms-docker/commit/f50d7a3))
+* **docker:** do not ignore files we need to COPY ([3205790](https://github.com/AEGEE/oms-docker/commit/3205790))
+* have to go around secrets ([d0b790f](https://github.com/AEGEE/oms-docker/commit/d0b790f))
 
 
 ### Features
 
-* **bodies:** allow unauthorized access for /bodies and /bodies/:id. Fixes MEMB-680 ([2652f68](https://github.com/AEGEE/oms-docker/commit/2652f68172f0c793285f3341ab625f6aeea185f8))
+* **bodies:** allow unauthorized access for /bodies and /bodies/:id. Fixes MEMB-680 ([2652f68](https://github.com/AEGEE/oms-docker/commit/2652f68))
 
 
 
-# [0.2.0](https://github.com/AEGEE/oms-docker/compare/e9c9e43b0b0f575c1fa8962fb31a582a0ae46729...0.2.0) (2019-08-29)
+# [0.2.0](https://github.com/AEGEE/oms-docker/compare/e9c9e43...0.2.0) (2019-08-29)
 
 
 ### Features
 
-* **general:** added conventional commits and changelog. Fixes MEMB-588 ([98bba99](https://github.com/AEGEE/oms-docker/commit/98bba99f3ea2e0cc0fbc7a30fe80622bf0038eee))
-* **general:** Healthcheck endpoint ([e9c9e43](https://github.com/AEGEE/oms-docker/commit/e9c9e43b0b0f575c1fa8962fb31a582a0ae46729))
+* **general:** added conventional commits and changelog. Fixes MEMB-588 ([98bba99](https://github.com/AEGEE/oms-docker/commit/98bba99))
+* **general:** Healthcheck endpoint ([e9c9e43](https://github.com/AEGEE/oms-docker/commit/e9c9e43))
 
 
 

--- a/lib/omscore_web/helper.ex
+++ b/lib/omscore_web/helper.ex
@@ -56,7 +56,14 @@ defmodule OmscoreWeb.Helper do
     key = Atom.to_string(attribute)
     query = if Map.has_key?(filters, key) do
       querystring = filters[key]
-      from q in query, where: ilike(field(q, ^attribute), ^"#{querystring}")
+
+      # If it's a string, just passing it into the ILIKE statement.
+      # If it's an array, pass it into the IN statement.
+      if is_binary(querystring) do
+        from q in query, where: ilike(field(q, ^attribute), ^"#{querystring}")
+      else
+        from q in query, where: field(q, ^attribute) in ^querystring
+      end
     else
       query
     end

--- a/lib/omscore_web/router.ex
+++ b/lib/omscore_web/router.ex
@@ -53,7 +53,7 @@ defmodule OmscoreWeb.Router do
   scope "/bodies/:body_id", OmscoreWeb, as: :body do
     pipe_through [:api]
 
-    get "", BodyController, :show
+    get "/", BodyController, :show
   end
 
   # For user-based request, don't fetch anything from the db but just validate the token

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oms-core-elixir",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oms-core-elixir",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "The core module of my.aegee.eu",
   "keywords": [],
   "author": "Nico Westerbeck",

--- a/test/omscore_web/controllers/body_controller_test.exs
+++ b/test/omscore_web/controllers/body_controller_test.exs
@@ -81,6 +81,21 @@ defmodule OmscoreWeb.BodyControllerTest do
       conn = get conn, body_path(conn, :index), [{"filter", %{"name" => "some really exotic query that definitely doesn't match any member at all"}}]
       assert json_response(conn, 200)["data"] == []
     end
+
+    test "filters if the values are passed as array", %{conn: conn} do
+      %{token: token} = create_member_with_permissions([%{action: "view", object: "body"}])
+      conn = put_req_header(conn, "x-auth-token", token)
+
+      {:ok, _} = Core.create_body(@create_attrs |> Map.put(:type, "antenna"))
+      {:ok, _} = Core.create_body(@create_attrs |> Map.put(:type, "contact"))
+      {:ok, _} = Core.create_body(@create_attrs |> Map.put(:type, "partner"))
+
+      conn = get conn, body_path(conn, :index), [{"filter", %{"type" => ["antenna", "contact"]}}]
+      response_data = json_response(conn, 200)["data"]
+      #IO.puts(response_data)
+
+      assert Kernel.length(response_data) === 2 # "partner" shouldn't be there
+    end
   end
 
   describe "index_campaigns" do


### PR DESCRIPTION
Fixes MEMB-731.
So now we can query `/bodies?filter[type][]=antenna&filter[type][]=contact` for getting both contacts and antennae. This applies to all the filters actually (so any of the `filter[something]` param can be either the array or the string).
The old syntax (aka `/bodies?filter[type]=antenna`) still works.

~~No idea if the tests will work though, I can't get them running on my local machine.~~ nevermind, I got it working and also added the tests for the new use-cases.